### PR TITLE
Refactored PR/23 to fully support scheduling

### DIFF
--- a/kytos.json
+++ b/kytos.json
@@ -4,7 +4,7 @@
   "name": "mef_eline",
   "description": "NApp to provision circuits from user request",
   "version": "2.1.0",
-  "napp_dependencies": ["kytos/flow_manager", "kytos/pathfinder"],
+  "napp_dependencies": ["kytos/flow_manager", "kytos/pathfinder", "kytos/storehouse"],
   "license": "MIT",
   "tags": [],
   "url": "https://github.com/kytos/mef_eline.git"

--- a/main.py
+++ b/main.py
@@ -191,12 +191,17 @@ class Main(KytosNApp):
         """
         # Try to create the circuit object
         data = request.get_json()
-        # get UNIs
-        data['uni_a'] = self._get_uni_from_request(data.get('uni_a'))
-        data['uni_z'] = self._get_uni_from_request(data.get('uni_z'))
+
+        name = data.get('name', None)
+        uni_a = self._get_uni_from_request(data.get('uni_a'))
+        uni_z = self._get_uni_from_request(data.get('uni_z'))
+        start_date = data.get('start_date', None)
+        end_date = data.get('end_date', None)
+        creation_time = data.get('creation_time', None)
 
         try:
-            circuit = EVC(**data)
+            circuit = EVC(name, uni_a, uni_z, start_date=start_date,
+                          end_date=end_date, creation_time=creation_time)
         except TypeError as exception:
             return jsonify("Bad request: {}".format(exception)), 400
 
@@ -252,11 +257,21 @@ class Main(KytosNApp):
     def schedule_all_stored_circuits(self):
         """Schedule all stored circuits"""
         store = self.store_items.get('circuits')
-        for evc in store.data.values():
-            options = evc.copy()
-            options['uni_a'] = self._get_uni_from_request(evc.get('uni_a'))
-            options['uni_z'] = self._get_uni_from_request(evc.get('uni_z'))
-            circuit = EVC(**options)
+
+        for data in store.data.values():
+            # get the evc attributes
+            name = data.get('name', None)
+            uni_a = self._get_uni_from_request(data.get('uni_a'))
+            uni_z = self._get_uni_from_request(data.get('uni_z'))
+            start_date = data.get('start_date', None)
+            end_date = data.get('end_date', None)
+            creation_time = data.get('creation_time', None)
+
+            # we no need try catch , because the data is already validated
+            circuit = EVC(name, uni_a, uni_z, start_date=start_date,
+                          end_date=end_date, creation_time=creation_time)
+
+            # schedule a circuit deploy event
             self.schedule.circuit_deploy(circuit)
             log.info(f'{circuit.id} loadded.')
 

--- a/main.py
+++ b/main.py
@@ -202,7 +202,7 @@ class Main(KytosNApp):
         try:
             circuit = EVC(name, uni_a, uni_z, start_date=start_date,
                           end_date=end_date, creation_time=creation_time)
-        except TypeError as exception:
+        except ValueError as exception:
             return jsonify("Bad request: {}".format(exception)), 400
 
         # Request paths to Pathfinder

--- a/main.py
+++ b/main.py
@@ -271,8 +271,8 @@ class Main(KytosNApp):
             circuit = EVC(name, uni_a, uni_z, start_date=start_date,
                           end_date=end_date, creation_time=creation_time)
 
-            # schedule a circuit deploy event
-            self.schedule.circuit_deploy(circuit)
+            # schedule a circuit deploy event if the event is not deployed yet
+            self.schedule.circuit_deploy(circuit, execute_elapsed_time=False)
             log.info(f'{circuit.id} loadded.')
 
     def save_evc(self, circuit):

--- a/main.py
+++ b/main.py
@@ -4,10 +4,12 @@ NApp to provision circuits from user request.
 """
 from datetime import datetime
 from datetime import timezone
+import json
 
 import requests
 from flask import jsonify, request
 
+from kytos.core.events import KytosEvent
 from kytos.core import KytosNApp, log, rest
 from kytos.core.interface import TAG, UNI
 from kytos.core.link import Link
@@ -30,6 +32,9 @@ class Main(KytosNApp):
 
         So, if you have any setup routine, insert it here.
         """
+        self.store_items = {}
+        self.verify_storehouse('circuits')
+
         self.execute_as_loop(1)
         self.schedule = Schedule()
 
@@ -149,11 +154,15 @@ class Main(KytosNApp):
 
     @rest('/v2/evc/', methods=['GET'])
     def list_circuits(self):
-        pass
+        """Rest endpoint to display all circuit informations."""
+        circuits = self.store_items.get('circuits').data
+        return jsonify(circuits), 200
 
     @rest('/v2/evc/<circuit_id>', methods=['GET'])
     def get_circuit(self, circuit_id):
-        pass
+        """Rest endpoint to display a specific circuit informations."""
+        circuits = self.store_items.get('circuits').data
+        return jsonify(circuits.get(circuit_id,{})), 200
 
     @rest('/v2/evc/', methods=['POST'])
     def create_circuit(self):
@@ -182,14 +191,12 @@ class Main(KytosNApp):
         """
         # Try to create the circuit object
         data = request.get_json()
-
-        name = data.get('name')
-        uni_a = self._get_uni_from_request(data.get('uni_a'))
-        uni_z = self._get_uni_from_request(data.get('uni_z'))
-        creation_time =  self._get_time_from_data(data.get('creation_time'))
+        # get UNIs
+        data['uni_a'] = self._get_uni_from_request(data.get('uni_a'))
+        data['uni_z'] = self._get_uni_from_request(data.get('uni_z'))
 
         try:
-            circuit = EVC(uni_a, uni_z, name, creation_time=creation_time)
+            circuit = EVC(**data)
         except TypeError as exception:
             return jsonify("Bad request: {}".format(exception)), 400
 
@@ -199,38 +206,78 @@ class Main(KytosNApp):
         # Schedule the circuit deploy
         self.schedule.circuit_deploy(circuit)
 
-        # Notify users
+        # Save evc
+        self.save_evc(circuit)
 
+        # Notify users
         return jsonify({"circuit_id": circuit.id}), 201
 
-    def _get_time_from_data(self, data=None):
-        """Receive a dictionary or a string and return a datatime instance.
+    def verify_storehouse(self, entities):
+        """Request a list of box saved by specific entity."""
+        name = 'kytos.storehouse.list'
+        content = {'namespace': f'kytos.mef_eline.{entities}',
+                   'callback': self.request_retrieve_entities}
+        event = KytosEvent(name=name, content=content)
+        self.controller.buffers.app.put(event)
+        log.info(f'verify data in storehouse for {entities}.')
 
-           data = {
-                 "year": 2006,
-                 "month": 11,
-                 "day": 21,
-                 "hour": 16,
-                 "minute": 30 ,
-                 "second": 00
-           }
+    def request_retrieve_entities(self, event, data, error):
+        """Retrieve the stored box or create a new box."""
+        msg = ''
+        content = {'namespace': event.content.get('namespace'),
+                   'callback': self.load_from_store,
+                   'data': {}}
 
-           or
-
-           data = "21/11/06 16:30:00"
-
-           2018-04-17T17:13:50Z
-
-        Args:
-            data (str, dict): python dict or string to be converted to datetime
-
-        Returns:
-            datetime: datetime instance.
-        """
-        if isinstance(data, str):
-            date =  datetime.strptime(data, "%Y-%m-%dT%H:%M:%S")
-        elif (isinstance(data, dict)):
-            date = datetime(**data)
+        if len(data) == 0:
+            name = 'kytos.storehouse.create'
+            msg = 'Create new box in storehouse'
         else:
-            return None
-        return date.replace(tzinfo=timezone.utc)
+            name = 'kytos.storehouse.retrieve'
+            content['box_id'] = data[0]
+            msg = 'Retrieve data from storeohouse.'
+
+        event = KytosEvent(name=name, content=content)
+        self.controller.buffers.app.put(event)
+        log.debug(msg)
+
+    def load_from_store(self, event, box, error):
+        """Save the data retrived from storehouse."""
+        entities = event.content.get('namespace', '').split('.')[-1]
+        if error:
+            log.error('Error while get a box from storehouse.')
+        else:
+            self.store_items[entities] = box
+            log.info('Data updated')
+
+    def schedule_all_stored_circuits(self):
+        """Schedule all stored circuits"""
+        store = self.store_items.get('circuits')
+        for evc in store.data.values():
+            options = evc.copy()
+            options['uni_a'] = self._get_uni_from_request(evc.get('uni_a'))
+            options['uni_z'] = self._get_uni_from_request(evc.get('uni_z'))
+            circuit = EVC(**options)
+            self.schedule.circuit_deploy(circuit)
+            log.info(f'{circuit.id} loadded.')
+
+    def save_evc(self, circuit):
+        """Save the circuit."""
+        store = self.store_items.get('circuits')
+        store.data[circuit.id] = circuit.as_dict()
+
+        name = 'kytos.storehouse.update'
+        content = {'namespace': 'kytos.mef_eline.circuits',
+                   'box_id': store.box_id,
+                   'data': store.data,
+                   'callback': self.update_instance}
+
+        event = KytosEvent(name=name, content=content)
+        self.controller.buffers.app.put(event)
+
+    def update_instance(self, event, data, error):
+        """Display in Kytos console if the data was updated."""
+        entities = event.content.get('namespace', '').split('.')[-1]
+        if error:
+            log.error(f'Error trying to update storehouse {entities}.')
+        else:
+            log.debug(f'Storehouse update to entities: {entities}.')

--- a/main.py
+++ b/main.py
@@ -147,7 +147,6 @@ class Main(KytosNApp):
 
         return uni
 
-    # New methods
     @rest('/v2/evc/', methods=['GET'])
     def list_circuits(self):
         pass

--- a/models.py
+++ b/models.py
@@ -16,14 +16,14 @@ class EVC:
 
     def __init__(self, name, uni_a, uni_z, start_date=None, end_date=None,
                  bandwidth=0, primary_links=None, backup_links=None,
-                 dynamic_backup_path=False, creation_time=None):
+                 dynamic_backup_path=False, creation_time=None, _id=None):
         """Create an EVC instance with the provided parameters.
 
         Do some basic validations to attributes.
         """
         self.validate(name, uni_a, uni_z)
 
-        self._id = uuid4().hex
+        self._id = _id if _id else uuid4().hex
         self.uni_a = uni_a
         self.uni_z = uni_z
         self.name = name

--- a/models.py
+++ b/models.py
@@ -31,8 +31,8 @@ class EVC:
         self.end_date = end_date
         # Bandwidth profile
         self.bandwidth = bandwidth
-        self.primary_links = primary_links
-        self.backup_links = backup_links
+        self.primary_links = primary_links if primary_links else []
+        self.backup_links = backup_links if backup_links else []
         self.dynamic_backup_path = dynamic_backup_path
         # dict with the user original request (input)
         self._requested = {}
@@ -95,59 +95,43 @@ class EVC:
                     "uni_a": self.uni_a.as_dict(),
                     "uni_z": self.uni_z.as_dict()}
 
-        if self.start_date:
-            date = self.start_date.strftime("%Y-%m-%dT%H:%M:%S")
-            evc_dict["start_date"] = date
+        time_fmt = "%Y-%m-%dT%H:%M:%S"
 
-        if self.end_date:
-            date = self.end_date.strftime("%Y-%m-%dT%H:%M:%S")
-            evc_dict['end_date'] = date
+        date = self.start_date.strftime(time_fmt)
+        evc_dict["start_date"] = date
 
-        if self.bandwidth:
-            evc_dict['bandwidth'] = self.bandwidth
+        date = self.end_date
+        if date:
+            date = self.end_date.strftime(time_fmt)
+        evc_dict['end_date'] = date
 
-        if self.primary_links:
-            evc_dict['primary_links'] = [link.as_dict() for link in
-                                         self.primary_links if link]
+        evc_dict['bandwidth'] = self.bandwidth
 
-        if self.backup_links:
-            evc_dict['backup_links'] = [link.as_dict() for link in
-                                        self.backup_links if link]
+        evc_dict['primary_links'] = [link.as_dict() for link in
+                                     self.primary_links if link]
 
-        if self.dynamic_backup_path:
-            evc_dict['dynamic_backup_path'] = self.dynamic_backup_path
+        evc_dict['backup_links'] = [link.as_dict() for link in
+                                    self.backup_links if link]
+
+        evc_dict['dynamic_backup_path'] = self.dynamic_backup_path
 
         if self._requested:
             evc_dict['_requested'] = self._requested
 
-        if self.current_path:
-            evc_dict['current_path'] = self.current_path
+        evc_dict['current_path'] = self.current_path
+        evc_dict['primary_path'] = self.primary_path
+        evc_dict['backup_path'] = self.backup_path
 
-        if self.primary_path:
-            evc_dict['primary_path'] = self.primary_path
+        time = self.request_time.strftime(time_fmt)
+        evc_dict['request_time'] = time
 
-        if self.backup_path:
-            evc_dict['backup_path'] = self.backup_path
+        time = self.creation_time.strftime(time_fmt)
+        evc_dict['creation_time'] = time
 
-        if self.request_time:
-            time = self.request_time.strftime("%Y-%m-%dT%H:%M:%S")
-            evc_dict['request_time'] = time
-
-        if self.creation_time:
-            time = self.creation_time.strftime("%Y-%m-%dT%H:%M:%S")
-            evc_dict['creation_time'] = time
-
-        if self.owner:
-            evc_dict['owner'] = self.owner
-
-        if self.active:
-            evc_dict['active'] = self.active
-
-        if self.enabled:
-            evc_dict['enabled'] = self.enabled
-
-        if self.priority:
-            evc_dict['priority'] = self.priority
+        evc_dict['owner'] = self.owner
+        evc_dict['active'] = self.active
+        evc_dict['enabled'] = self.enabled
+        evc_dict['priority'] = self.priority
 
         return evc_dict
 

--- a/models.py
+++ b/models.py
@@ -49,7 +49,7 @@ class EVC:
         # created)
         self.request_time = now()
         # datetime when the circuit should be activated. now() || schedule()
-        self.creation_time =  creation_time or now()
+        self.creation_time = get_time(creation_time) or now()
         self.owner = None
         # Operational State
         self.active = False
@@ -130,6 +130,10 @@ class EVC:
         if self.request_time:
            time = self.request_time.strftime("%Y-%m-%dT%H:%M:%S")
            evc_dict['request_time'] = time
+
+        if self.creation_time:
+           time = self.creation_time.strftime("%Y-%m-%dT%H:%M:%S")
+           evc_dict['creation_time'] = time
 
         if self.owner:
            evc_dict['owner'] = self.owner

--- a/models.py
+++ b/models.py
@@ -62,32 +62,31 @@ class EVC:
         """Validate the EVC arguments.
 
         Raises:
-            TypeError: Raises an error with the error message, when the params
-                       are invalid.
+            ValueError: raised when object attributes are invalid.
         """
         # Verify required attributes
         if name is None:
-            raise TypeError("name is required.")
+            raise ValueError("name is required.")
 
         if uni_a is None:
-            raise TypeError("uni_a is required")
+            raise ValueError("uni_a is required")
 
         if uni_z is None:
-            raise TypeError('uni_z is required')
+            raise ValueError('uni_z is required')
 
         # Verify UNIs instances
         if not isinstance(uni_a, UNI):
-            raise TypeError("Invalid uni_a.")
+            raise ValueError("Invalid uni_a.")
 
         if not isinstance(uni_z, UNI):
-            raise TypeError("Invalid uni_z.")
+            raise ValueError("Invalid uni_z.")
 
         # Verify if UNIs is valid
         if not uni_a.is_valid():
-            raise TypeError("Invalid uni_a.")
+            raise ValueError("Invalid uni_a.")
 
         if not uni_z.is_valid():
-            raise TypeError("Invalid uni_z.")
+            raise ValueError("Invalid uni_z.")
 
     def as_dict(self):
         """A dictionary representing an EVC object."""

--- a/schedule.py
+++ b/schedule.py
@@ -16,7 +16,12 @@ class Schedule:
         self.scheduler.run(False)
         time.sleep(1)
 
-    def circuit_deploy(self, circuit):
+    def circuit_deploy(self, circuit, execute_elapsed_time=True):
         """Add a new circuit deploy event."""
+
         seconds = (circuit.creation_time - now()).total_seconds()
+
+        if execute_elapsed_time is False and seconds < 0:
+            return
+
         self.scheduler.enter(seconds, 1, circuit.deploy)

--- a/schedule.py
+++ b/schedule.py
@@ -16,12 +16,15 @@ class Schedule:
         self.scheduler.run(False)
         time.sleep(1)
 
-    def circuit_deploy(self, circuit, execute_elapsed_time=True):
-        """Add a new circuit deploy event."""
+    def circuit_enable(self, circuit, execute_elapsed_time=True):
+        """Schedule an EVC to be enabled.
+
+        Only enable EVCs that haven't been enabled yet.
+        """
 
         seconds = (circuit.creation_time - now()).total_seconds()
 
         if execute_elapsed_time is False and seconds < 0:
             return
 
-        self.scheduler.enter(seconds, 1, circuit.deploy)
+        self.scheduler.enter(seconds, 1, circuit.enable)

--- a/settings.py
+++ b/settings.py
@@ -1,4 +1,6 @@
 """Settings for the mef_eline NApp."""
+# Namespace
+NAMESPACE = 'kytos.mef_eline.circuits'
 
 # Base URL of the Pathfinder endpoint
 PATHFINDER_URL = 'http://localhost:8181/api/kytos/pathfinder/v2/'


### PR DESCRIPTION
Hi @macartur @beraldoleal @hdiogenes. It turns out I was working with @macartur on PR #23. I've refactored a few things to fully support scheduling. I have implemented integration tests with storehouse (these theses haven't been pushed yet, I just used to validate the code):

Let me know if you'd rather merge PR #23 first before I push this. I figured I'd be easier to merge at once.

```
def test_get_all(eline_url):
    """Test get all EVCs."""
    req = requests.get(eline_url)
    assert req.status_code == 200


def test_post_evc(eline_url, evc_dict):
    """Test post EVC"""
    req = requests.post(eline_url, json=evc_dict)
    assert req.status_code == 201

    # bad request
    req = requests.post(eline_url, {"name": "whatever"})
    assert req.status_code == 400


def test_get_evc_id(eline_url, evc_dict):
    """Test get EVC."""
    req = requests.post(eline_url, json=evc_dict)
    assert req.status_code == 201
    data = req.json()
    evc_id = str(data['circuit_id'])

    req = requests.get(f"{eline_url}/{evc_id}")
    assert req.status_code == 201 or req.status_code == 200
```

Results:
```
~/repos/napps/kytos/mef_eline pr/23*
❯ pytest -s -v
============================================================================================= test session starts =============================================================================================
platform linux -- Python 3.6.5, pytest-3.5.1, py-1.5.3, pluggy-0.6.0 -- /home/arcanjo/repos/napps/kytos/mef_eline/.direnv/python-3.6.5/bin/python3
cachedir: .pytest_cache
rootdir: /home/arcanjo/repos/napps/kytos/mef_eline, inifile:
collected 3 items

tests/test_mef_eline.py::test_get_all PASSED
tests/test_mef_eline.py::test_post_evc PASSED
tests/test_mef_eline.py::test_get_evc_id PASSED
```