### PR TITLE
Add attribute already_registered_jobs

### DIFF
--- a/scheduler.py
+++ b/scheduler.py
@@ -48,6 +48,7 @@ class Scheduler:
         """Create a new schedule structure."""
         self.scheduler = BackgroundScheduler(timezone=utc)
         self.scheduler.start()
+        self.already_registered_jobs = set()
 
     def shutdown(self):
         """Shutdown the scheduler."""
@@ -56,6 +57,9 @@ class Scheduler:
     def add(self, circuit):
         """Add all circuit_scheduler from specific circuit."""
         for circuit_scheduler in circuit.circuit_scheduler:
+            if circuit_scheduler.id in self.already_registered_jobs:
+                continue
+
             data = {'id': circuit_scheduler.id}
             action = None
 
@@ -79,6 +83,8 @@ class Scheduler:
                 cron = CronTrigger.from_crontab(circuit_scheduler.frequency,
                                                 timezone=utc)
                 self.scheduler.add_job(action, cron, **data)
+
+            self.already_registered_jobs.add(circuit_scheduler.id)
 
     def cancel_job(self, circuit_scheduler_id):
         """Cancel a specific job from scheduler."""

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -88,7 +88,7 @@ class TestScheduler(TestCase):
 
     @patch('apscheduler.schedulers.background.BackgroundScheduler.add_job')
     @patch('napps.kytos.mef_eline.models.EVC._validate')
-    def test_new_circuit_with_run_time(self, validate_mock,
+    def test_new_circuit_with_run_date(self, validate_mock,
                                        scheduler_add_job_mock):
         """Test if add new circuit with run_time."""
         scheduler_add_job_mock.return_value = True
@@ -109,6 +109,8 @@ class TestScheduler(TestCase):
             }
         scheduler_add_job_mock.assert_called_once_with(evc.remove, 'date',
                                                        **expected_parameters)
+        self.assertIn(circuit_scheduler.id,
+                      self.scheduler.already_registered_jobs)
 
     @patch('apscheduler.schedulers.background.BackgroundScheduler.add_job')
     @patch('napps.kytos.mef_eline.models.EVC._validate')
@@ -139,6 +141,8 @@ class TestScheduler(TestCase):
         }
         scheduler_add_job_mock.assert_called_once_with(evc.deploy, 'interval',
                                                        **expected_parameters)
+        self.assertIn(circuit_scheduler.id,
+                      self.scheduler.already_registered_jobs)
 
     @patch('apscheduler.triggers.cron.CronTrigger.from_crontab')
     @patch('apscheduler.schedulers.background.BackgroundScheduler.add_job')
@@ -172,3 +176,6 @@ class TestScheduler(TestCase):
         }
         scheduler_add_job_mock.assert_called_once_with(evc.deploy, trigger,
                                                        **expected_parameters)
+
+        self.assertIn(circuit_scheduler.id,
+                      self.scheduler.already_registered_jobs)


### PR DESCRIPTION
This attribute will store the circuit_scheduler id to avoid add same circuit or
crete a loop with the trigger_evc_reprovisioning method.