### PR TITLE
Added handle_switches_settings to configure UNI available_tags

### DIFF
--- a/main.py
+++ b/main.py
@@ -218,22 +218,24 @@ class Main(KytosNApp):
     def handle_switches_settings(self, event):
         """Apply switch settings whenever a new switch port is created.
 
-        This is the first event after a handshake when we know
-        for sure that the port object reference has been updated."""
+        This is the first event after a handshake, when we know for sure
+        that the port object reference has been updated.
+        """
         dpid = event.content.get('switch')
-        if dpid:
-            debug_msg = "Setting VLANs {} on sw {} on port {}"
-            vlan_pool = settings.VLAN_POOL_OVERRIDE
-            if dpid in vlan_pool:
-                ofp_ports = vlan_pool[dpid]
-                switch_ref = self.controller.switches[dpid]
-                for ofp_port, vlan_range in ofp_ports.items():
-                    intf = switch_ref.interfaces.get(ofp_port)
-                    if intf:
-                        if intf.available_tags != vlan_range:
-                            log.debug(debug_msg.format(str(vlan_range),
-                                                       dpid, str(ofp_port)))
-                            intf.set_available_tags(vlan_range)
+        if not dpid:
+            return
+        vlan_pool = settings.VLAN_POOL_OVERRIDE
+        if dpid not in vlan_pool:
+            return
+        ofp_ports = vlan_pool[dpid]
+        switch_ref = self.controller.switches[dpid]
+        for ofp_port, vlan_range in ofp_ports.items():
+            intf = switch_ref.interfaces.get(ofp_port)
+            if not intf or intf.available_tags == vlan_range:
+                continue
+            log.debug("Setting VLANs %s on switch %s, port %s",
+                      vlan_range, dpid, ofp_port)
+            intf.set_available_tags(vlan_range)
 
     def evc_from_dict(self, evc_dict):
         """Convert some dict values to instance of EVC classes.

--- a/settings.py
+++ b/settings.py
@@ -5,3 +5,16 @@ PATHFINDER_URL = 'http://localhost:8181/api/kytos/pathfinder/v2/'
 
 # Base URL of the Flow Manager endpoint
 MANAGER_URL = 'http://localhost:8181/api/kytos/flow_manager/v2'
+
+# VLAN pool settings
+
+# The VLAN pool settings is a dictionary of datapath id, which contains
+# a dictionary of of_port numbers with the respective vlan pool range
+# that should be used on this of_port. See the example below, which
+# sets the vlan range from 101 to 119 for of_ports 1 and 4:
+
+# vlan_ids should be an iterable of int values between 1 and 4095
+# vlan_ids = range(101, 120)
+# VLAN_POOL_OVERRIDE = {"00:00:00:00:00:00:00:01": {1: vlan_ids, 4: vlan_ids}}
+
+VLAN_POOL_OVERRIDE = {}


### PR DESCRIPTION
Fixed #86. 

Since all NApps already have an instance of the controller, and other NApps, such as `kytos/of_core` are already settings `kytos.core.*` attributes, I figured this approach would be reasonable. So I decided not take the route to provide a global settings on `kytos.conf` for now, and use a dictionary in the settings.py to update the attributes accordingly. 