### PR TITLE
Scheduler recording its usage

### DIFF
--- a/main.py
+++ b/main.py
@@ -200,7 +200,8 @@ class Main(KytosNApp):
                 log.debug(f'{data.get("id")} can not be provisioning yet.')
                 continue
 
-            evc.handle_link_up(event.content['link'])
+            if evc.schedule_active:
+                evc.handle_link_up(event.content['link'])
 
     @listen_to('kytos/topology.link_down')
     def handle_link_down(self, event):
@@ -214,7 +215,7 @@ class Main(KytosNApp):
                 log.debug(f'{data.get("id")} can not be provisioned yet.')
                 continue
 
-            if evc.is_affected_by_link(event.content['link']):
+            if evc.is_active() and evc.is_affected_by_link(event.content['link']):
                 log.info('handling evc %s' % evc)
                 evc.handle_link_down()
 

--- a/scheduler.py
+++ b/scheduler.py
@@ -60,9 +60,9 @@ class Scheduler:
             action = None
 
             if circuit_scheduler.action == 'create':
-                action = circuit.deploy
+                action = circuit.schedule_deploy
             elif circuit_scheduler.action == 'remove':
-                action = circuit.remove
+                action = circuit.schedule_remove
 
             if circuit_scheduler.date:
                 data.update({'run_date': circuit_scheduler.date})


### PR DESCRIPTION
When deploy/remove is called by the scheduler, a new attribute of the EVC, `schedule_active`, is set to `True` when deploying and to `False` when removed. This attribute is then checked when dealing with a link up event.