### PR TITLE
New REST API's to EVC Schedules

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,3 +1,6 @@
 [run]
 source = .
 omit = *tests*,.tox/*
+
+[xml]
+output=coverage.xml

--- a/.gitignore
+++ b/.gitignore
@@ -52,3 +52,5 @@ venv/
 ENV/
 .spyderproject
 .ropeproject
+/.idea/
+.idea/

--- a/main.py
+++ b/main.py
@@ -213,9 +213,13 @@ class Main(KytosNApp):
 
         result = []
         for circuit in circuits:
-            if "circuit_scheduler" in circuit:
-                schedule = {circuit["id"]: circuit["circuit_scheduler"]}
-                result.append(schedule)
+            circuit_scheduler = circuit.get("circuit_scheduler")
+            if circuit_scheduler:
+                for scheduler in circuit_scheduler:
+                    value = {"schedule_id": scheduler.get("id"),
+                             "circuit_id": circuit.get("id"),
+                             "schedule": scheduler}
+                    result.append(value)
 
         return jsonify(result), 200
 

--- a/main.py
+++ b/main.py
@@ -216,13 +216,13 @@ class Main(KytosNApp):
         """Endpoint to return list all schedule from a circuit."""
         circuits = self.storehouse.get_data()
 
-        if circuit_id in circuits:
-            circuit = circuits[circuit_id]
-            result = circuit["circuit_scheduler"]
-            status = 200
-        else:
+        if circuit_id not in circuits:
             result = {'response': f'circuit_id {circuit_id} not found'}
-            status = 400
+            return jsonify(result), 404
+
+        circuit = circuits[circuit_id]
+        result = circuit["circuit_scheduler"]
+        status = 200
 
         return jsonify(result), status
 
@@ -457,8 +457,7 @@ class Main(KytosNApp):
 
             if attribute == 'circuit_scheduler':
                 data[attribute] = []
-                for schedule in value:
-                    data[attribute].append(CircuitSchedule.from_dict(schedule))
+                data[attribute].append(CircuitSchedule.from_dict(value))
 
             if 'link' in attribute:
                 if value:

--- a/main.py
+++ b/main.py
@@ -351,10 +351,7 @@ class Main(KytosNApp):
             evc.circuit_scheduler.remove(found_schedule)
 
             # Cancel all schedule jobs
-            for schedule in evc.circuit_scheduler:
-                self.sched.cancel_job(schedule.id)
-            # Add all the circuit schedules again
-            self.sched.add(evc)
+            self.sched.cancel_job(found_schedule.id)
             # Save EVC to the storehouse
             self.storehouse.save_evc(evc)
 

--- a/main.py
+++ b/main.py
@@ -232,6 +232,13 @@ class Main(KytosNApp):
         Create a new schedule for a given circuit.
 
         This service do no check if there are conflicts with another schedule.
+        Example:
+            {
+              "date": "2019-08-07T14:52:10.967Z",
+              "interval": "string",
+              "frequency": "1 * * *",
+              "action": "create"
+            }
         """
         # Try to create the circuit object
         data = request.get_json()
@@ -261,10 +268,13 @@ class Main(KytosNApp):
         # Add the new schedule
         evc.circuit_scheduler.append(new_schedule)
 
+        # Add schedule job
+        self.sched.add_circuit_job(evc, new_schedule)
+
         # save circuit
         self.storehouse.save_evc(evc)
 
-        return jsonify({"schedule_id": new_schedule.id}), 201
+        return jsonify(new_schedule.as_dict()), 201
 
     @rest('/v2/evc/<circuit_id>/schedule/<schedule_id>', methods=['PATCH'])
     def update_schedule(self, circuit_id, schedule_id):

--- a/main.py
+++ b/main.py
@@ -282,9 +282,6 @@ class Main(KytosNApp):
 
         Change all attributes from the given schedule from a EVC circuit.
         The schedule ID is preserved as default, but it can also be modified.
-
-        The scheduler is notified and refresh all the schedules from
-        the given EVC circuit.
         """
         data = request.get_json()
         circuits = self.storehouse.get_data()
@@ -312,14 +309,13 @@ class Main(KytosNApp):
                 evc.circuit_scheduler.append(new_schedule)
 
                 # Cancel all schedule jobs
-                for schedule in evc.circuit_scheduler:
-                    self.sched.cancel_job(schedule.id)
-                # Add all the circuit schedules again
-                self.sched.add(evc)
+                self.sched.cancel_job(found_schedule.id)
+                # Add the new circuit schedule
+                self.sched.add_circuit_job(evc, new_schedule)
                 # Save EVC to the storehouse
                 self.storehouse.save_evc(evc)
 
-                result = {evc.id: evc.as_dict()}
+                result = new_schedule.as_dict()
                 status = 200
             else:
                 result = {'response': f'schedule_id {schedule_id} not found'}

--- a/main.py
+++ b/main.py
@@ -200,7 +200,13 @@ class Main(KytosNApp):
 
     @rest('/v2/evc/schedule', methods=['GET'])
     def list_schedules(self):
-        """Endpoint to return all circuits stored."""
+        """Endpoint to return all schedules stored for all circuits.
+
+        Return a JSON with the following template:
+        [{"schedule_id": <schedule_id>,
+         "circuit_id": <circuit_id>,
+         "schedule": <schedule object>}]
+        """
         circuits = self.storehouse.get_data().values()
         if not circuits:
             return jsonify({}), 200

--- a/openapi.yml
+++ b/openapi.yml
@@ -111,6 +111,122 @@ paths:
         '200':
           description: OK
 
+  /v2/evc/schedule/:
+    get:
+      summary: List all schedules stored.
+      description: List all circuits stored.
+      operationId: list_circuit_schedules
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/CircuitSchedule'
+
+  /v2/evc/{circuit_id}/schedule/:
+    get:
+      summary: Get all schedules stored for on circuit.
+      description: Get all circuits stored for on circuit.
+      operationId: get_circuit_schedules
+      parameters:
+        - name: circuit_id
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/CircuitSchedule'
+
+    post:
+      summary: Creates a new circuit schedule
+      operationId: create_schedule
+      parameters:
+        - name: circuit_id
+          in: path
+          required: true
+          schema:
+            type: string
+      requestBody:
+        description: Creates a new schedule.
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CircuitSchedule'
+      responses:
+        '201':
+          description: Schedule created. The circuit ID is being returned.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  circuit_id: # the unique schedule id
+                    type: string
+        '400':
+          description: Request do not have a JSON or JSON format do not match
+            the EVC object or EVC already exists.
+        '409':
+          description: Not Acceptable.
+  /v2/evc/{circuit_id}/schedule/{schedule_id}:
+    patch:
+      summary: Update a circuit schedule
+      description: Update a circuit schedule based on payload. The circuit_id and schedule_id are required.
+      operationId: update_schedule
+      parameters:
+        - name: circuit_id
+          in: path
+          required: true
+          schema:
+            type: string
+        - name: schedule_id
+          in: path
+          required: true
+          schema:
+            type: string
+      requestBody:
+        description: Update a circuit schedule based on the circuit_id, schedule_id and payload given
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CircuitSchedule'
+      responses:
+        '200':
+          description: OK
+        '404':
+          description: Circuit id or Schedule id not found.
+        '400':
+          description: Bad request.
+    delete:
+      summary: Delete a circuit schedule
+      description: Delete a schedule from a circuit.
+      operationId: delete_schedule
+      parameters:
+        - name: circuit_id
+          in: path
+          required: true
+          schema:
+            type: string
+        - name: schedule_id
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: OK
+
 components:
   schemas:
     NewCircuit:

--- a/openapi.yml
+++ b/openapi.yml
@@ -113,8 +113,8 @@ paths:
 
   /v2/evc/schedule/:
     get:
-      summary: List all schedules stored.
-      description: List all circuits stored.
+      summary: List all schedules stored for all circuits .
+      description: List all schedules stored for all circuits .
       operationId: list_circuit_schedules
       responses:
         '200':
@@ -124,13 +124,13 @@ paths:
               schema:
                 type: array
                 items:
-                  $ref: '#/components/schemas/CircuitSchedule'
+                  $ref: '#/components/schemas/CircuitScheduleList'
 
     post:
       summary: Creates a new circuit schedule
       operationId: create_schedule
       requestBody:
-        description: Creates a new schedule.
+        description: Creates a new circuit schedule.
         required: true
         content:
           application/json:
@@ -138,19 +138,18 @@ paths:
               $ref: '#/components/schemas/NewCircuitSchedule'
       responses:
         '201':
-          description: Schedule created. The circuit ID is being returned.
+          description: Schedule created. The Schedule object is being returned.
           content:
             application/json:
               schema:
-                type: object
-                properties:
-                  circuit_id: # the unique schedule id
-                    type: string
+                $ref: '#/components/schemas/CircuitSchedule'
         '400':
           description: Request do not have a JSON or JSON format do not match
-            the EVC object or EVC already exists.
+            the Schedule object or some parameters are missing.
         '404':
           description: Circuit id not found.
+        '403':
+          description:  Can´t change data. Circuit is deleted and archived.
         '409':
           description: Not Acceptable.
 
@@ -175,10 +174,12 @@ paths:
       responses:
         '200':
           description: OK
+        '400':
+          description: Bad request. Invalid format or some parameters are missing.
+        '403':
+          description:  Can´t change data. Circuit is deleted and archived.
         '404':
           description: Schedule id not found.
-        '400':
-          description: Bad request.
     delete:
       summary: Delete a circuit schedule
       description: Delete a schedule from a circuit.
@@ -192,11 +193,16 @@ paths:
       responses:
         '200':
           description: OK
+        '403':
+          description:  Can´t change data. Circuit is deleted and archived.
         '404':
           description:  Schedule id not found.
 components:
+  #-------------------------------
+  # Reusable schemas (data models)
+  #-------------------------------
   schemas:
-    NewCircuit:
+    NewCircuit: # Can be referenced via '#/components/schemas/NewCircuit'
       type: object
       required:
         - name
@@ -231,7 +237,7 @@ components:
           items:
             $ref: '#/components/schemas/CircuitSchedule'
 
-    Endpoint:
+    Endpoint: # Can be referenced via '#/components/schemas/Endpoint'
       type: object
       required:
         - interface_id
@@ -241,7 +247,8 @@ components:
           format: '00:00:00:00:00:00:00:00:0'
         tag:
           $ref: '#/components/schemas/Tag'
-    Link:
+
+    Link: # Can be referenced via '#/components/schemas/Link'
       type: object
       required:
         - id
@@ -254,7 +261,8 @@ components:
           $ref: '#/components/schemas/Endpoint'
         endpoint_b:
           $ref: '#/components/schemas/Endpoint'
-    Path:
+
+    Path: # Can be referenced via '#/components/schemas/Path'
       type: object
       required:
         - endpoints
@@ -266,7 +274,8 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/Endpoint'
-    Circuit:
+
+    Circuit: # Can be referenced via '#/components/schemas/Circuit'
       type: object
       required:
         - id
@@ -336,7 +345,8 @@ components:
         request_time:
           type: string
           format: date-time
-    Tag:
+
+    Tag: # Can be referenced via '#/components/schemas/Tag'
       type: object
       required:
         - tag_type
@@ -346,7 +356,8 @@ components:
           type: string
         value:
           type: string
-    CircuitSchedule:
+
+    CircuitSchedule: # Can be referenced via '#/components/schemas/CircuitSchedule'
       type: object
       properties:
         id:
@@ -361,10 +372,26 @@ components:
           type: string
         action:
           type: string
+
+  #------------------------------------------
+  # Reusable schemas for request or responses
+  #------------------------------------------
     NewCircuitSchedule:
       type: object
       properties:
         circuit_id:
+          type: integer
+          format: int32
+        schedule: {
+            "$ref": "#/components/schemas/CircuitSchedule"
+        }
+    CircuitScheduleList:
+      type: object
+      properties:
+        circuit_id:
+          type: integer
+          format: int32
+        schedule_id:
           type: integer
           format: int32
         schedule: {

--- a/openapi.yml
+++ b/openapi.yml
@@ -126,43 +126,16 @@ paths:
                 items:
                   $ref: '#/components/schemas/CircuitSchedule'
 
-  /v2/evc/{circuit_id}/schedule/:
-    get:
-      summary: Get all schedules stored for on circuit.
-      description: Get all circuits stored for on circuit.
-      operationId: get_circuit_schedules
-      parameters:
-        - name: circuit_id
-          in: path
-          required: true
-          schema:
-            type: string
-      responses:
-        '200':
-          description: OK
-          content:
-            application/json:
-              schema:
-                type: array
-                items:
-                  $ref: '#/components/schemas/CircuitSchedule'
-
     post:
       summary: Creates a new circuit schedule
       operationId: create_schedule
-      parameters:
-        - name: circuit_id
-          in: path
-          required: true
-          schema:
-            type: string
       requestBody:
         description: Creates a new schedule.
         required: true
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/CircuitSchedule'
+              $ref: '#/components/schemas/NewCircuitSchedule'
       responses:
         '201':
           description: Schedule created. The circuit ID is being returned.
@@ -176,26 +149,24 @@ paths:
         '400':
           description: Request do not have a JSON or JSON format do not match
             the EVC object or EVC already exists.
+        '404':
+          description: Circuit id not found.
         '409':
           description: Not Acceptable.
-  /v2/evc/{circuit_id}/schedule/{schedule_id}:
+
+  /v2/evc/schedule/{schedule_id}:
     patch:
       summary: Update a circuit schedule
-      description: Update a circuit schedule based on payload. The circuit_id and schedule_id are required.
+      description: Update a circuit schedule based on payload. The schedule_id are required.
       operationId: update_schedule
       parameters:
-        - name: circuit_id
-          in: path
-          required: true
-          schema:
-            type: string
         - name: schedule_id
           in: path
           required: true
           schema:
             type: string
       requestBody:
-        description: Update a circuit schedule based on the circuit_id, schedule_id and payload given
+        description: Update a circuit schedule based on the schedule_id and payload given
         required: true
         content:
           application/json:
@@ -205,7 +176,7 @@ paths:
         '200':
           description: OK
         '404':
-          description: Circuit id or Schedule id not found.
+          description: Schedule id not found.
         '400':
           description: Bad request.
     delete:
@@ -213,11 +184,6 @@ paths:
       description: Delete a schedule from a circuit.
       operationId: delete_schedule
       parameters:
-        - name: circuit_id
-          in: path
-          required: true
-          schema:
-            type: string
         - name: schedule_id
           in: path
           required: true
@@ -226,7 +192,8 @@ paths:
       responses:
         '200':
           description: OK
-
+        '404':
+          description:  Schedule id not found.
 components:
   schemas:
     NewCircuit:
@@ -394,3 +361,12 @@ components:
           type: string
         action:
           type: string
+    NewCircuitSchedule:
+      type: object
+      properties:
+        circuit_id:
+          type: integer
+          format: int32
+        schedule: {
+            "$ref": "#/components/schemas/CircuitSchedule"
+        }

--- a/scheduler.py
+++ b/scheduler.py
@@ -1,7 +1,6 @@
 """Module responsible to handle schedulers."""
 from uuid import uuid4
 
-from apscheduler.jobstores.base import ConflictingIdError
 from apscheduler.jobstores.base import JobLookupError
 from apscheduler.schedulers.background import BackgroundScheduler
 from apscheduler.triggers.cron import CronTrigger

--- a/scheduler.py
+++ b/scheduler.py
@@ -2,6 +2,7 @@
 from uuid import uuid4
 
 from apscheduler.jobstores.base import ConflictingIdError
+from apscheduler.jobstores.base import JobLookupError
 from apscheduler.schedulers.background import BackgroundScheduler
 from apscheduler.triggers.cron import CronTrigger
 from pytz import utc
@@ -91,4 +92,8 @@ class Scheduler:
 
     def cancel_job(self, circuit_scheduler_id):
         """Cancel a specific job from scheduler."""
-        self.scheduler.remove_job(circuit_scheduler_id)
+        try:
+            self.scheduler.remove_job(circuit_scheduler_id)
+        except JobLookupError as job_error:
+            # Job was not found... Maybe someone already remove it.
+            log.error(job_error)

--- a/scheduler.py
+++ b/scheduler.py
@@ -53,7 +53,11 @@ class CircuitSchedule:
 
 
 class Scheduler:
-    """Class to schedule the circuits rules."""
+    """Class to schedule the circuits rules.
+
+    It is responsible to create/remove schedule jobs based on
+    Circuit Schedules.
+    """
 
     def __init__(self):
         """Create a new schedule structure."""
@@ -70,6 +74,7 @@ class Scheduler:
 
         Args:
             circuit (napps.kytos.mef_eline.models.EVCBase): EVC circuit
+
         """
         for circuit_scheduler in circuit.circuit_scheduler:
             self.add_circuit_job(circuit, circuit_scheduler)
@@ -122,6 +127,7 @@ class Scheduler:
                         'minutes': 3
                     }
                 if job_call is frequency, the template is the cron format.
+
         """
         if circuit_scheduler.date:
             self.scheduler.add_job(job_call, 'date', **data)

--- a/setup.py
+++ b/setup.py
@@ -74,8 +74,9 @@ class TestCoverage(SimpleCommand):
 
     def run(self):
         """Run unittest quietly and display coverage report."""
-        cmd = 'coverage3 run -m unittest && coverage3 report'
-        check_call(cmd, shell=True)
+        call('rm .coverage coverage.xml', shell=True)
+        call('coverage3 run -m unittest', shell=True)
+        call('coverage3 report && coverage3 xml', shell=True)
 
 
 class Linter(SimpleCommand):
@@ -115,7 +116,8 @@ class KytosInstall:
             napp_path = Path('kytos', napp)
             src = ENABLED_PATH / napp_path
             dst = INSTALLED_PATH / napp_path
-            src.symlink_to(dst)  # pylint: disable=no-member
+            if not os.path.islink(src):
+                src.symlink_to(dst)  # pylint: disable=no-member
 
 
 class InstallMode(install):
@@ -174,19 +176,22 @@ class DevelopMode(develop):
         links.mkdir(parents=True, exist_ok=True)  # pylint: disable=no-member
         code = CURRENT_DIR
         src = links / 'mef_eline'
-        src.symlink_to(code)  # pylint: disable=no-member
+        if not os.path.islink(src):
+            src.symlink_to(code)  # pylint: disable=no-member
 
         # pylint: disable=no-member
         (ENABLED_PATH / 'kytos').mkdir(parents=True, exist_ok=True)
         dst = ENABLED_PATH / Path('kytos', 'mef_eline')
-        dst.symlink_to(src)  # pylint: disable=no-member
+        if not os.path.islink(dst):
+            dst.symlink_to(src)  # pylint: disable=no-member
 
     @staticmethod
     def _create_file_symlinks():
         """Symlink to required files."""
         src = ENABLED_PATH / '__init__.py'
         dst = CURRENT_DIR / 'napps' / '__init__.py'
-        src.symlink_to(dst)  # pylint: disable=no-member
+        if not os.path.islink(src):
+            src.symlink_to(dst)  # pylint: disable=no-member
 
 
 setup(name='kytos_mef_eline',

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -67,7 +67,7 @@ class TestMain(TestCase):  # pylint: disable=too-many-public-methods
         urls = self.get_napp_urls(self.napp)
         self.assertCountEqual(expected_urls, urls)
 
-    @patch('napps.kytos.mef_eline.main.Main.uni_from_dict')
+    @patch('napps.kytos.mef_eline.main.Main._uni_from_dict')
     @patch('napps.kytos.mef_eline.models.EVCBase._validate')
     def test_evc_from_dict(self, _validate_mock, uni_from_dict_mock):
         """
@@ -98,14 +98,15 @@ class TestMain(TestCase):  # pylint: disable=too-many-public-methods
                 "action": "create"
             }]
         }
-        evc_response = self.napp.evc_from_dict(payload)
+        # pylint: disable=protected-access
+        evc_response = self.napp._evc_from_dict(payload)
         self.assertIsNotNone(evc_response)
         self.assertIsNotNone(evc_response.uni_a)
         self.assertIsNotNone(evc_response.uni_z)
         self.assertIsNotNone(evc_response.circuit_scheduler)
         self.assertIsNotNone(evc_response.name)
 
-    @patch('napps.kytos.mef_eline.main.Main.uni_from_dict')
+    @patch('napps.kytos.mef_eline.main.Main._uni_from_dict')
     @patch('napps.kytos.mef_eline.models.EVCBase._validate')
     @patch('kytos.core.Controller.get_interface_by_id')
     def test_evc_from_dict_paths(self, _get_interface_by_id_mock,
@@ -142,7 +143,8 @@ class TestMain(TestCase):  # pylint: disable=too-many-public-methods
             "backup_path": []
         }
 
-        evc_response = self.napp.evc_from_dict(payload)
+        # pylint: disable=protected-access
+        evc_response = self.napp._evc_from_dict(payload)
         self.assertIsNotNone(evc_response)
         self.assertIsNotNone(evc_response.uni_a)
         self.assertIsNotNone(evc_response.uni_z)
@@ -152,7 +154,7 @@ class TestMain(TestCase):  # pylint: disable=too-many-public-methods
         self.assertEqual(len(evc_response.backup_path), 0)
         self.assertEqual(len(evc_response.primary_path), 1)
 
-    @patch('napps.kytos.mef_eline.main.Main.uni_from_dict')
+    @patch('napps.kytos.mef_eline.main.Main._uni_from_dict')
     @patch('napps.kytos.mef_eline.models.EVCBase._validate')
     @patch('kytos.core.Controller.get_interface_by_id')
     def test_evc_from_dict_links(self, _get_interface_by_id_mock,
@@ -188,7 +190,8 @@ class TestMain(TestCase):  # pylint: disable=too-many-public-methods
             "backup_links": []
         }
 
-        evc_response = self.napp.evc_from_dict(payload)
+        # pylint: disable=protected-access
+        evc_response = self.napp._evc_from_dict(payload)
         self.assertIsNotNone(evc_response)
         self.assertIsNotNone(evc_response.uni_a)
         self.assertIsNotNone(evc_response.uni_z)
@@ -261,7 +264,7 @@ class TestMain(TestCase):  # pylint: disable=too-many-public-methods
 
     @patch('napps.kytos.mef_eline.storehouse.StoreHouse.get_data')
     @patch('napps.kytos.mef_eline.scheduler.Scheduler.add')
-    @patch('napps.kytos.mef_eline.main.Main.uni_from_dict')
+    @patch('napps.kytos.mef_eline.main.Main._uni_from_dict')
     @patch('napps.kytos.mef_eline.storehouse.StoreHouse.save_evc')
     @patch('napps.kytos.mef_eline.main.EVC.as_dict')
     @patch('napps.kytos.mef_eline.models.EVC._validate')
@@ -369,7 +372,7 @@ class TestMain(TestCase):  # pylint: disable=too-many-public-methods
         self.assertEqual(current_data, expected_data)
 
     @patch('napps.kytos.mef_eline.scheduler.Scheduler.add')
-    @patch('napps.kytos.mef_eline.main.Main.uni_from_dict')
+    @patch('napps.kytos.mef_eline.main.Main._uni_from_dict')
     @patch('napps.kytos.mef_eline.storehouse.StoreHouse.save_evc')
     @patch('napps.kytos.mef_eline.models.EVC._validate')
     @patch('napps.kytos.mef_eline.main.EVC.as_dict')
@@ -798,7 +801,7 @@ class TestMain(TestCase):  # pylint: disable=too-many-public-methods
     @patch('apscheduler.schedulers.background.BackgroundScheduler.add_job')
     @patch('napps.kytos.mef_eline.storehouse.StoreHouse.get_data')
     @patch('napps.kytos.mef_eline.scheduler.Scheduler.add')
-    @patch('napps.kytos.mef_eline.main.Main.uni_from_dict')
+    @patch('napps.kytos.mef_eline.main.Main._uni_from_dict')
     @patch('napps.kytos.mef_eline.storehouse.StoreHouse.save_evc')
     @patch('napps.kytos.mef_eline.main.EVC.as_dict')
     @patch('napps.kytos.mef_eline.models.EVC._validate')
@@ -847,7 +850,7 @@ class TestMain(TestCase):  # pylint: disable=too-many-public-methods
     @patch('apscheduler.schedulers.background.BackgroundScheduler.remove_job')
     @patch('napps.kytos.mef_eline.storehouse.StoreHouse.get_data')
     @patch('napps.kytos.mef_eline.scheduler.Scheduler.add')
-    @patch('napps.kytos.mef_eline.main.Main.uni_from_dict')
+    @patch('napps.kytos.mef_eline.main.Main._uni_from_dict')
     @patch('napps.kytos.mef_eline.storehouse.StoreHouse.save_evc')
     @patch('napps.kytos.mef_eline.main.EVC.as_dict')
     @patch('napps.kytos.mef_eline.models.EVC._validate')
@@ -916,7 +919,7 @@ class TestMain(TestCase):  # pylint: disable=too-many-public-methods
 
     @patch('napps.kytos.mef_eline.storehouse.StoreHouse.get_data')
     @patch('napps.kytos.mef_eline.scheduler.Scheduler.add')
-    @patch('napps.kytos.mef_eline.main.Main.uni_from_dict')
+    @patch('napps.kytos.mef_eline.main.Main._uni_from_dict')
     @patch('napps.kytos.mef_eline.main.EVC.as_dict')
     @patch('napps.kytos.mef_eline.models.EVC._validate')
     def test_update_schedule_archived(self, *args):
@@ -962,7 +965,7 @@ class TestMain(TestCase):  # pylint: disable=too-many-public-methods
 
     @patch('apscheduler.schedulers.background.BackgroundScheduler.remove_job')
     @patch('napps.kytos.mef_eline.storehouse.StoreHouse.get_data')
-    @patch('napps.kytos.mef_eline.main.Main.uni_from_dict')
+    @patch('napps.kytos.mef_eline.main.Main._uni_from_dict')
     @patch('napps.kytos.mef_eline.storehouse.StoreHouse.save_evc')
     @patch('napps.kytos.mef_eline.main.EVC.as_dict')
     @patch('napps.kytos.mef_eline.models.EVC._validate')
@@ -1017,7 +1020,7 @@ class TestMain(TestCase):  # pylint: disable=too-many-public-methods
         self.assertIn("Schedule removed", f"{response.data}")
 
     @patch('napps.kytos.mef_eline.storehouse.StoreHouse.get_data')
-    @patch('napps.kytos.mef_eline.main.Main.uni_from_dict')
+    @patch('napps.kytos.mef_eline.main.Main._uni_from_dict')
     @patch('napps.kytos.mef_eline.main.EVC.as_dict')
     @patch('napps.kytos.mef_eline.models.EVC._validate')
     def test_delete_schedule_archived(self, *args):

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -9,7 +9,8 @@ from napps.kytos.mef_eline.main import Main
 from tests.helpers import get_controller_mock
 
 
-class TestMain(TestCase):  # pylint: disable=too-many-public-methods
+# pylint: disable=too-many-public-methods, too-many-lines
+class TestMain(TestCase):
     """Test the Main class."""
 
     def setUp(self):
@@ -738,22 +739,22 @@ class TestMain(TestCase):  # pylint: disable=too-many-public-methods
         # Call URL
         response = api.get(url)
         # Expected JSON data from response
-        expected = [{"aa:aa:aa":
-                    [{"action": "create",
-                      "frequency": "* * * * *",
-                      "id": "1"},
-                     {"action": "remove",
-                      "frequency": "1 * * * *",
-                      "id": "2"}]},
-                    {"bb:bb:bb":
-                        [{"action": "create",
-                          "frequency": "1 * * * *",
-                          "id": "3"},
-                         {"action": "remove",
-                          "frequency": "2 * * * *",
-                          "id": "4"}]}
-
-                    ]
+        expected = [{'circuit_id': 'aa:aa:aa',
+                     'schedule': {'action': 'create',
+                                  'frequency': '* * * * *', 'id': '1'},
+                     'schedule_id': '1'},
+                    {'circuit_id': 'aa:aa:aa',
+                     'schedule': {'action': 'remove',
+                                  'frequency': '1 * * * *', 'id': '2'},
+                     'schedule_id': '2'},
+                    {'circuit_id': 'bb:bb:bb',
+                     'schedule': {'action': 'create',
+                                  'frequency': '1 * * * *', 'id': '3'},
+                     'schedule_id': '3'},
+                    {'circuit_id': 'bb:bb:bb',
+                     'schedule': {'action': 'remove',
+                                  'frequency': '2 * * * *', 'id': '4'},
+                     'schedule_id': '4'}]
 
         self.assertEqual(response.status_code, 200, response.data)
         self.assertEqual(expected, json.loads(response.data))

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -100,6 +100,103 @@ class TestMain(TestCase):  # pylint: disable=too-many-public-methods
         }
         evc_response = self.napp.evc_from_dict(payload)
         self.assertIsNotNone(evc_response)
+        self.assertIsNotNone(evc_response.uni_a)
+        self.assertIsNotNone(evc_response.uni_z)
+        self.assertIsNotNone(evc_response.circuit_scheduler)
+        self.assertIsNotNone(evc_response.name)
+
+    @patch('napps.kytos.mef_eline.main.Main.uni_from_dict')
+    @patch('napps.kytos.mef_eline.models.EVCBase._validate')
+    @patch('kytos.core.Controller.get_interface_by_id')
+    def test_evc_from_dict_paths(self, _get_interface_by_id_mock,
+                                 _validate_mock, uni_from_dict_mock):
+        """
+        Test the helper method that create an EVN from dict.
+
+        Verify object creation with circuit data and schedule data.
+        """
+        _get_interface_by_id_mock.return_value = True
+        _validate_mock.return_value = True
+        uni_from_dict_mock.side_effect = ['uni_a', 'uni_z']
+        payload = {
+            "name": "my evc1",
+            "uni_a": {
+                "interface_id": "00:00:00:00:00:00:00:01:1",
+                "tag": {
+                    "tag_type": 1,
+                    "value": 80
+                }
+            },
+            "uni_z": {
+                "interface_id": "00:00:00:00:00:00:00:02:2",
+                "tag": {
+                    "tag_type": 1,
+                    "value": 1
+                }
+            },
+            "current_path": [],
+            "primary_path": [
+                {"endpoint_a": {"interface_id": "00:00:00:00:00:00:00:01:1"},
+                 "endpoint_b": {"interface_id": "00:00:00:00:00:00:00:02:2"}}
+            ],
+            "backup_path": []
+        }
+
+        evc_response = self.napp.evc_from_dict(payload)
+        self.assertIsNotNone(evc_response)
+        self.assertIsNotNone(evc_response.uni_a)
+        self.assertIsNotNone(evc_response.uni_z)
+        self.assertIsNotNone(evc_response.circuit_scheduler)
+        self.assertIsNotNone(evc_response.name)
+        self.assertEqual(len(evc_response.current_path), 0)
+        self.assertEqual(len(evc_response.backup_path), 0)
+        self.assertEqual(len(evc_response.primary_path), 1)
+
+    @patch('napps.kytos.mef_eline.main.Main.uni_from_dict')
+    @patch('napps.kytos.mef_eline.models.EVCBase._validate')
+    @patch('kytos.core.Controller.get_interface_by_id')
+    def test_evc_from_dict_links(self, _get_interface_by_id_mock,
+                                 _validate_mock, uni_from_dict_mock):
+        """
+        Test the helper method that create an EVN from dict.
+
+        Verify object creation with circuit data and schedule data.
+        """
+        _get_interface_by_id_mock.return_value = True
+        _validate_mock.return_value = True
+        uni_from_dict_mock.side_effect = ['uni_a', 'uni_z']
+        payload = {
+            "name": "my evc1",
+            "uni_a": {
+                "interface_id": "00:00:00:00:00:00:00:01:1",
+                "tag": {
+                    "tag_type": 1,
+                    "value": 80
+                }
+            },
+            "uni_z": {
+                "interface_id": "00:00:00:00:00:00:00:02:2",
+                "tag": {
+                    "tag_type": 1,
+                    "value": 1
+                }
+            },
+            "primary_links": [
+                {"endpoint_a": {"interface_id": "00:00:00:00:00:00:00:01:1"},
+                 "endpoint_b": {"interface_id": "00:00:00:00:00:00:00:02:2"}}
+            ],
+            "backup_links": []
+        }
+
+        evc_response = self.napp.evc_from_dict(payload)
+        self.assertIsNotNone(evc_response)
+        self.assertIsNotNone(evc_response.uni_a)
+        self.assertIsNotNone(evc_response.uni_z)
+        self.assertIsNotNone(evc_response.circuit_scheduler)
+        self.assertIsNotNone(evc_response.name)
+        self.assertEqual(len(evc_response.current_links_cache), 0)
+        self.assertEqual(len(evc_response.backup_links), 0)
+        self.assertEqual(len(evc_response.primary_links), 1)
 
     def test_list_without_circuits(self):
         """Test if list circuits return 'no circuit stored.'."""

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py36,coverage,lint
+envlist = coverage,lint
 
 [testenv]
 whitelist_externals=


### PR DESCRIPTION
Fix issue #105 
New API REST services to list, get, create, update and delete EVC Schedules.

For the servicde Delete I silenced the Exception about lookup the job.
If the job is not found, I assume that the job is already removed.