### PR TITLE
Fix enable on update.

### DIFF
--- a/models.py
+++ b/models.py
@@ -252,9 +252,17 @@ class EVCBase(GenericEntity):
             if attribute in self.unique_attributes:
                 raise ValueError(f'{attribute} can\'t be be updated.')
             if hasattr(self, attribute):
-                if 'enable' in attribute:
-                    self.enable()
+                if attribute in ('enable', 'enabled'):
+                    if value:
+                        self.enable()
+                    else:
+                        self.disable()
                     enable = value
+                elif attribute in ('active', 'activate'):
+                    if value:
+                        self.activate()
+                    else:
+                        self.deactivate()
                 else:
                     setattr(self, attribute, value)
                     if 'path' in attribute:

--- a/models.py
+++ b/models.py
@@ -252,11 +252,13 @@ class EVCBase(GenericEntity):
             if attribute in self.unique_attributes:
                 raise ValueError(f'{attribute} can\'t be be updated.')
             if hasattr(self, attribute):
-                setattr(self, attribute, value)
                 if 'enable' in attribute:
+                    self.enable()
                     enable = value
-                elif 'path' in attribute:
-                    path = value
+                else:
+                    setattr(self, attribute, value)
+                    if 'path' in attribute:
+                        path = value
             else:
                 raise ValueError(f'The attribute "{attribute}" is invalid.')
         self.sync()


### PR DESCRIPTION
Updating the enable attribute on an EVC was causing an error, because the method
'enable' was been replaced by an attribute. Now, instead of updating attribute
'enable', method 'enable()' is called. Fix #186.