### PR TITLE
Try more paths when the first has no tag available.

### DIFF
--- a/models.py
+++ b/models.py
@@ -121,7 +121,7 @@ class DynamicPathManager:
 
     @classmethod
     def get_best_paths(cls, circuit):
-        """Return the best path available for a circuit, if exists."""
+        """Return the best paths available for a circuit, if they exist."""
         for path in cls.get_paths(circuit):
             yield cls.create_path(path['hops'])
 
@@ -376,7 +376,7 @@ class EVCDeploy(EVCBase):
         """Create a EVC."""
 
     def discover_new_paths(self):
-        """Discover a new path to satisfy this circuit and deploy."""
+        """Discover new paths to satisfy this circuit and deploy it."""
         return DynamicPathManager.get_best_paths(self)
 
     def change_path(self):

--- a/models.py
+++ b/models.py
@@ -6,6 +6,7 @@ import requests
 
 from kytos.core import log
 from kytos.core.common import EntityStatus, GenericEntity
+from kytos.core.exceptions import KytosNoTagAvailableError
 from kytos.core.helpers import get_time, now
 from kytos.core.interface import UNI
 from kytos.core.link import Link
@@ -117,6 +118,12 @@ class DynamicPathManager:
         if paths:
             return cls.create_path(cls.get_paths(circuit)[0]['hops'])
         return None
+
+    @classmethod
+    def get_best_paths(cls, circuit):
+        """Return the best path available for a circuit, if exists."""
+        for path in cls.get_paths(circuit):
+            yield cls.create_path(path['hops'])
 
     @classmethod
     def create_path(cls, path):
@@ -368,9 +375,9 @@ class EVCDeploy(EVCBase):
     def create(self):
         """Create a EVC."""
 
-    def discover_new_path(self):
+    def discover_new_paths(self):
         """Discover a new path to satisfy this circuit and deploy."""
-        return DynamicPathManager.get_best_path(self)
+        return DynamicPathManager.get_best_paths(self)
 
     def change_path(self):
         """Change EVC path."""
@@ -549,19 +556,31 @@ class EVCDeploy(EVCBase):
 
         """
         self.remove_current_flows()
-        if not self.should_deploy(path):
-            path = self.discover_new_path()
-            if not path:
-                return False
+        use_path = path
+        if self.should_deploy(use_path):
+            try:
+                use_path.choose_vlans()
+            except KytosNoTagAvailableError:
+                use_path = None
+        else:
+            for use_path in self.discover_new_paths():
+                try:
+                    use_path.choose_vlans()
+                    break
+                except KytosNoTagAvailableError:
+                    pass
+            else:
+                use_path = None
 
-        path.choose_vlans()
-        self._install_nni_flows(path)
-        self._install_uni_flows(path)
-        self.activate()
-        self.current_path = path
-        self.sync()
-        log.info(f"{self} was deployed.")
-        return True
+        if use_path:
+            self._install_nni_flows(use_path)
+            self._install_uni_flows(use_path)
+            self.activate()
+            self.current_path = use_path
+            self.sync()
+            log.info(f"{self} was deployed.")
+            return True
+        return False
 
     def _install_nni_flows(self, path=None):
         """Install NNI flows."""

--- a/tests/unit/models/test_evc_deploy.py
+++ b/tests/unit/models/test_evc_deploy.py
@@ -403,8 +403,8 @@ class TestEVC(TestCase):  # pylint: disable=too-many-public-methods
         self.assertTrue(deployed)
 
     @patch('napps.kytos.mef_eline.models.log')
-    @patch('napps.kytos.mef_eline.models.EVC.discover_new_path',
-           return_value=None)
+    @patch('napps.kytos.mef_eline.models.EVC.discover_new_paths',
+           return_value=[])
     @patch('napps.kytos.mef_eline.models.Path.choose_vlans')
     @patch('napps.kytos.mef_eline.models.EVC._install_nni_flows')
     @patch('napps.kytos.mef_eline.models.EVC._install_uni_flows')
@@ -416,8 +416,8 @@ class TestEVC(TestCase):  # pylint: disable=too-many-public-methods
         """Test if all methods is ignored when the should_deploy is false."""
         # pylint: disable=too-many-locals
         (sync_mock, should_deploy_mock, activate_mock, install_uni_flows_mock,
-         install_nni_flows, chose_vlans_mock,
-         discover_new_path, log_mock) = args
+         install_nni_flows, choose_vlans_mock,
+         discover_new_paths, log_mock) = args
 
         uni_a = get_uni_mocked(interface_port=2, tag_value=82,
                                switch_id="switch_uni_a",
@@ -444,12 +444,12 @@ class TestEVC(TestCase):  # pylint: disable=too-many-public-methods
         evc = EVC(**attributes)
         deployed = evc.deploy_to_path()
 
-        self.assertEqual(discover_new_path.call_count, 1)
+        self.assertEqual(discover_new_paths.call_count, 1)
         self.assertEqual(should_deploy_mock.call_count, 1)
         self.assertEqual(activate_mock.call_count, 0)
         self.assertEqual(install_uni_flows_mock.call_count, 0)
         self.assertEqual(install_nni_flows.call_count, 0)
-        self.assertEqual(chose_vlans_mock.call_count, 0)
+        self.assertEqual(choose_vlans_mock.call_count, 0)
         self.assertEqual(log_mock.info.call_count, 0)
         self.assertEqual(sync_mock.call_count, 1)
         self.assertFalse(deployed)
@@ -460,11 +460,11 @@ class TestEVC(TestCase):  # pylint: disable=too-many-public-methods
     @patch('napps.kytos.mef_eline.models.EVC._install_uni_flows')
     @patch('napps.kytos.mef_eline.models.EVC.activate')
     @patch('napps.kytos.mef_eline.models.EVC.should_deploy')
-    @patch('napps.kytos.mef_eline.models.EVC.discover_new_path')
+    @patch('napps.kytos.mef_eline.models.EVC.discover_new_paths')
     def test_deploy_without_path_case1(self, *args):
         """Test if not path is found a dynamic path is used."""
         # pylint: disable=too-many-locals
-        (discover_new_path_mocked, should_deploy_mock, activate_mock,
+        (discover_new_paths_mocked, should_deploy_mock, activate_mock,
          install_uni_flows_mock, install_nni_flows, chose_vlans_mock,
          log_mock) = args
 
@@ -491,7 +491,7 @@ class TestEVC(TestCase):  # pylint: disable=too-many-public-methods
         ])
 
         evc = EVC(**attributes)
-        discover_new_path_mocked.return_value = dynamic_backup_path
+        discover_new_paths_mocked.return_value = [dynamic_backup_path]
 
         # storehouse initialization mock
         evc._storehouse.box = Mock()  # pylint: disable=protected-access
@@ -500,7 +500,7 @@ class TestEVC(TestCase):  # pylint: disable=too-many-public-methods
         deployed = evc.deploy_to_path()
 
         self.assertEqual(should_deploy_mock.call_count, 1)
-        self.assertEqual(discover_new_path_mocked.call_count, 1)
+        self.assertEqual(discover_new_paths_mocked.call_count, 1)
         self.assertEqual(activate_mock.call_count, 1)
         self.assertEqual(install_uni_flows_mock.call_count, 1)
         self.assertEqual(install_nni_flows.call_count, 1)

--- a/tests/unit/models/test_link_protection.py
+++ b/tests/unit/models/test_link_protection.py
@@ -297,13 +297,11 @@ class TestLinkProtection(TestCase):  # pylint: disable=too-many-public-methods
         log_mocked.debug.assert_called_once_with(msg)
 
     @patch('napps.kytos.mef_eline.models.log')
-    @patch('napps.kytos.mef_eline.models.EVCDeploy.deploy')
+    @patch('napps.kytos.mef_eline.models.EVCDeploy.deploy_to_path')
     @patch('napps.kytos.mef_eline.models.EVCDeploy._send_flow_mods')
-    @patch('napps.kytos.mef_eline.models.DynamicPathManager.get_best_path')
     @patch(DEPLOY_TO_PRIMARY_PATH)
     @patch('napps.kytos.mef_eline.models.Path.status', EntityStatus.DOWN)
     def test_handle_link_down_case_4(self, deploy_to_mocked,
-                                     get_best_path_mocked,
                                      _send_flow_mods_mocked,
                                      deploy_mocked,
                                      log_mocked):
@@ -345,8 +343,6 @@ class TestLinkProtection(TestCase):  # pylint: disable=too-many-public-methods
         evc._storehouse.box.data = {}  # pylint: disable=protected-access
 
         current_handle_link_down = evc.handle_link_down()
-
-        self.assertEqual(get_best_path_mocked.call_count, 1)
         self.assertEqual(deploy_to_mocked.call_count, 1)
 
         self.assertTrue(current_handle_link_down)


### PR DESCRIPTION
Method to get shortest path now returns more paths. So,
if the first has no tag available, the second is tried,
and so on. Fix #189.