### PR TITLE
Accept EVCs where UNI has no tag.

### DIFF
--- a/main.py
+++ b/main.py
@@ -613,9 +613,6 @@ class Main(KytosNApp):
             tag = None
         else:
             tag = TAG.from_dict(tag_dict)
-            if tag is False:
-                raise ValueError(f'Could not instantiate tag from dict '
-                                 '{tag_dict}')
         uni = UNI(interface, tag)
 
         return uni

--- a/main.py
+++ b/main.py
@@ -607,11 +607,15 @@ class Main(KytosNApp):
         if interface is None:
             raise ValueError(f'Could not instantiate interface {interface_id}')
 
-        tag_dict = uni_dict.get("tag")
-        tag = TAG.from_dict(tag_dict)
-        if tag is False:
-            raise ValueError(f'Could not instantiate tag from dict {tag_dict}')
-
+        try:
+            tag_dict = uni_dict["tag"]
+        except KeyError:
+            tag = None
+        else:
+            tag = TAG.from_dict(tag_dict)
+            if tag is False:
+                raise ValueError(f'Could not instantiate tag from dict '
+                                 '{tag_dict}')
         uni = UNI(interface, tag)
 
         return uni

--- a/models.py
+++ b/models.py
@@ -687,26 +687,30 @@ class EVCDeploy(EVCBase):
         in_interface, out_interface, in_vlan, out_vlan, new_in_vlan = args
 
         flow_mod = self._prepare_flow_mod(in_interface, out_interface)
-        flow_mod['match']['dl_vlan'] = in_vlan
+        if in_vlan:
+            flow_mod['match']['dl_vlan'] = in_vlan
 
-        new_action = {"action_type": "set_vlan",
-                      "vlan_id": out_vlan}
+        new_action = {"action_type": "set_vlan", "vlan_id": out_vlan}
         flow_mod["actions"].insert(0, new_action)
 
-        new_action = {"action_type": "push_vlan",
-                      "tag_type": "s"}
+        new_action = {"action_type": "push_vlan", "tag_type": "s"}
         flow_mod["actions"].insert(0, new_action)
 
-        new_action = {"action_type": "set_vlan",
-                      "vlan_id": new_in_vlan}
-        flow_mod["actions"].insert(0, new_action)
-
+        if new_in_vlan:
+            new_action = {"action_type": "set_vlan", "vlan_id": new_in_vlan}
+            flow_mod["actions"].insert(0, new_action)
+            if not in_vlan:
+                new_action = {"action_type": "push_vlan", "tag_type": "c"}
+                flow_mod["actions"].insert(0, new_action)
+        elif in_vlan:
+            new_action = {"action_type": "pop_vlan"}
+            flow_mod["actions"].insert(0, new_action)
         return flow_mod
 
-    def _prepare_pop_flow(self, in_interface, out_interface, in_vlan):
+    def _prepare_pop_flow(self, in_interface, out_interface, out_vlan):
         """Prepare pop flow."""
         flow_mod = self._prepare_flow_mod(in_interface, out_interface)
-        flow_mod['match']['dl_vlan'] = in_vlan
+        flow_mod['match']['dl_vlan'] = out_vlan
         new_action = {"action_type": "pop_vlan"}
         flow_mod["actions"].insert(0, new_action)
         return flow_mod

--- a/models.py
+++ b/models.py
@@ -687,22 +687,29 @@ class EVCDeploy(EVCBase):
         in_interface, out_interface, in_vlan, out_vlan, new_in_vlan = args
 
         flow_mod = self._prepare_flow_mod(in_interface, out_interface)
-        if in_vlan:
-            flow_mod['match']['dl_vlan'] = in_vlan
 
+        # the service tag must be always pushed
         new_action = {"action_type": "set_vlan", "vlan_id": out_vlan}
         flow_mod["actions"].insert(0, new_action)
 
         new_action = {"action_type": "push_vlan", "tag_type": "s"}
         flow_mod["actions"].insert(0, new_action)
 
+        if in_vlan:
+            # if in_vlan is set, it must be included in the match
+            flow_mod['match']['dl_vlan'] = in_vlan
         if new_in_vlan:
+            # new_in_vlan is set, so an action to set it is necessary
             new_action = {"action_type": "set_vlan", "vlan_id": new_in_vlan}
             flow_mod["actions"].insert(0, new_action)
             if not in_vlan:
+                # new_in_vlan is set, but in_vlan is not, so there was no
+                # vlan set; then it is set now
                 new_action = {"action_type": "push_vlan", "tag_type": "c"}
                 flow_mod["actions"].insert(0, new_action)
         elif in_vlan:
+            # in_vlan is set, but new_in_vlan is not, so the existing vlan
+            # must be removed
             new_action = {"action_type": "pop_vlan"}
             flow_mod["actions"].insert(0, new_action)
         return flow_mod


### PR DESCRIPTION
Now mef_eline accepts EVCs where a UNI has no tag. Deploy method now
install the correct flows for that case. Fix #190.