### PR TITLE
Update return messages and codes when an error happens

### DIFF
--- a/main.py
+++ b/main.py
@@ -186,26 +186,27 @@ class Main(KytosNApp):
                     log.error(exception)
                     result = {'response': 'Bad Request: {}'.format(exception)}
                     status = 400
-                except TypeError:
-                    result = {'response': 'Content-Type must be '
-                                          'application/json'}
-                    status = 415
                 except BadRequest:
                     response = 'Bad Request: The request is not a valid JSON.'
                     result = {'response': response}
                     status = 400
                 else:
-                    if evc.is_active():
-                        if enable is False:  # disable if active
-                            evc.remove()
-                        elif path is not None:  # redeploy if active
-                            evc.remove()
-                            evc.deploy()
+                    if data is None:
+                        result = {'response': 'Content-Type must be '
+                                              'application/json'}
+                        status = 415
                     else:
-                        if enable is True:  # enable if inactive
-                            evc.deploy()
-                    result = {evc.id: evc.as_dict()}
-                    status = 200
+                        if evc.is_active():
+                            if enable is False:  # disable if active
+                                evc.remove()
+                            elif path is not None:  # redeploy if active
+                                evc.remove()
+                                evc.deploy()
+                        else:
+                            if enable is True:  # enable if inactive
+                                evc.deploy()
+                        result = {evc.id: evc.as_dict()}
+                        status = 200
 
         log.debug('update result %s %s', result, status)
         return jsonify(result), status

--- a/main.py
+++ b/main.py
@@ -300,22 +300,8 @@ class Main(KytosNApp):
             }
         """
         log.debug('create_schedule /v2/evc/schedule/')
-        try:
-            # Try to create the circuit object
-            json_data = request.get_json()
-        except ValueError as exception:
-            log.error(exception)
-            log.debug('create_schedule result %s %s', exception, 400)
-            raise BadRequest(str(exception))
-        except BadRequest:
-            result = 'The request is not a valid JSON.'
-            log.debug('create_schedule result %s %s', result, 400)
-            raise BadRequest(result)
-        if json_data is None:
-            result = 'Content-Type must be application/json'
-            log.debug('create_schedule result %s %s', result, 415)
-            raise UnsupportedMediaType(result)
 
+        json_data = self.json_from_request('create_schedule')
         try:
             circuit_id = json_data['circuit_id']
         except TypeError:
@@ -402,20 +388,7 @@ class Main(KytosNApp):
             log.debug('update_schedule result %s %s', result, 403)
             raise Forbidden(result)
 
-        try:
-            data = request.get_json()
-        except ValueError as exception:
-            log.error(exception)
-            log.debug('update_schedule result %s %s', exception, 400)
-            raise BadRequest(str(exception))
-        except BadRequest:
-            result = 'The request is not a valid JSON.'
-            log.debug('update_schedule result %s %s', result, 400)
-            raise BadRequest(result)
-        if data is None:
-            result = 'Content-Type must be application/json'
-            log.debug('create_schedule result %s %s', result, 415)
-            raise UnsupportedMediaType(result)
+        data = self.json_from_request('update_schedule')
 
         new_schedule = CircuitSchedule.from_dict(data)
         new_schedule.id = found_schedule.id
@@ -674,3 +647,27 @@ class Main(KytosNApp):
                 evc = self._evc_from_dict(circuit)
                 self.circuits[c_id] = evc
         return self.circuits
+
+    @staticmethod
+    def json_from_request(caller):
+        """Return a json from request.
+
+        If it was not possible to get a json from the request, log, for debug,
+        who was the caller and the error that ocurred, and raise an
+        Exception.
+        """
+        try:
+            json_data = request.get_json()
+        except ValueError as exception:
+            log.error(exception)
+            log.debug(f'{caller} result {exception} 400')
+            raise BadRequest(str(exception))
+        except BadRequest:
+            result = 'The request is not a valid JSON.'
+            log.debug(f'{caller} result {result} 400')
+            raise BadRequest(result)
+        if json_data is None:
+            result = 'Content-Type must be application/json'
+            log.debug(f'{caller} result {result} 415')
+            raise UnsupportedMediaType(result)
+        return json_data

--- a/main.py
+++ b/main.py
@@ -132,9 +132,8 @@ class Main(KytosNApp):
         try:
             evc = self._evc_from_dict(data)
         except ValueError as exception:
-            result = "{}".format(exception)
-            log.debug('create_circuit result %s %s', result, 400)
-            raise BadRequest(result)
+            log.debug('create_circuit result %s %s', exception, 400)
+            raise BadRequest(str(exception))
 
         # verify duplicated evc
         if self._is_duplicated_evc(evc):

--- a/main.py
+++ b/main.py
@@ -3,8 +3,9 @@
 NApp to provision circuits from user request.
 """
 from flask import jsonify, request
-from werkzeug.exceptions import (BadRequest, Conflict, NotFound,
-                                 MethodNotAllowed, UnsupportedMediaType)
+from werkzeug.exceptions import (BadRequest, Conflict, Forbidden,
+                                 MethodNotAllowed, NotFound,
+                                 UnsupportedMediaType)
 
 from kytos.core import KytosNApp, log, rest
 from kytos.core.events import KytosEvent
@@ -199,9 +200,8 @@ class Main(KytosNApp):
                 evc.update(**self._evc_dict_with_instances(data))
         except ValueError as exception:
             log.error(exception)
-            result = '{}'.format(exception)
-            log.debug('update result %s %s', result, 400)
-            raise BadRequest(exception)
+            log.debug('update result %s %s', exception, 400)
+            raise BadRequest(str(exception))
 
         if evc.is_active():
             if enable is False:  # disable if active
@@ -303,76 +303,72 @@ class Main(KytosNApp):
         try:
             # Try to create the circuit object
             json_data = request.get_json()
-
-            circuit_id = json_data.get("circuit_id")
-            schedule_data = json_data.get("schedule")
-
-            if not json_data:
-                result = "Bad request: The request does not have a json."
-                status = 400
-                log.debug('create_schedule result %s %s', result, status)
-                return jsonify(result), status
-            if not circuit_id:
-                result = "Bad request: Missing circuit_id."
-                status = 400
-                log.debug('create_schedule result %s %s', result, status)
-                return jsonify(result), status
-            if not schedule_data:
-                result = "Bad request: Missing schedule data."
-                status = 400
-                log.debug('create_schedule result %s %s', result, status)
-                return jsonify(result), status
-
-            # Get EVC from circuits buffer
-            circuits = self._get_circuits_buffer()
-
-            # get the circuit
-            evc = circuits.get(circuit_id)
-
-            # get the circuit
-            if not evc:
-                result = {'response': f'circuit_id {circuit_id} not found'}
-                status = 404
-                log.debug('create_schedule result %s %s', result, status)
-                return jsonify(result), status
-            # Can not modify circuits deleted and archived
-            if evc.archived:
-                result = {'response': f'Circuit is archived.'
-                                      f'Update is forbidden.'}
-                status = 403
-                log.debug('create_schedule result %s %s', result, status)
-                return jsonify(result), status
-
-            # new schedule from dict
-            new_schedule = CircuitSchedule.from_dict(schedule_data)
-
-            # If there is no schedule, create the list
-            if not evc.circuit_scheduler:
-                evc.circuit_scheduler = []
-
-            # Add the new schedule
-            evc.circuit_scheduler.append(new_schedule)
-
-            # Add schedule job
-            self.sched.add_circuit_job(evc, new_schedule)
-
-            # save circuit to storehouse
-            evc.sync()
-
-            result = new_schedule.as_dict()
-            status = 201
-
         except ValueError as exception:
             log.error(exception)
-            result = {'response': 'Bad Request: {}'.format(exception)}
-            status = 400
-        except TypeError:
-            result = {'response': 'Content-Type must be application/json'}
-            status = 415
+            log.debug('create_schedule result %s %s', exception, 400)
+            raise BadRequest(str(exception))
         except BadRequest:
-            response = 'Bad Request: The request is not a valid JSON.'
-            result = {'response': response}
-            status = 400
+            result = 'The request is not a valid JSON.'
+            log.debug('create_schedule result %s %s', result, 400)
+            raise BadRequest(result)
+        if json_data is None:
+            result = 'Content-Type must be application/json'
+            log.debug('create_schedule result %s %s', result, 415)
+            raise UnsupportedMediaType(result)
+
+        try:
+            circuit_id = json_data['circuit_id']
+        except TypeError:
+            result = 'The payload should have a dictionary.'
+            log.debug('create_schedule result %s %s', result, 400)
+            raise BadRequest(result)
+        except KeyError:
+            result = 'Missing circuit_id.'
+            log.debug('create_schedule result %s %s', result, 400)
+            raise BadRequest(result)
+
+        try:
+            schedule_data = json_data['schedule']
+        except KeyError:
+            result = 'Missing schedule data.'
+            log.debug('create_schedule result %s %s', result, 400)
+            raise BadRequest(result)
+
+        # Get EVC from circuits buffer
+        circuits = self._get_circuits_buffer()
+
+        # get the circuit
+        evc = circuits.get(circuit_id)
+
+        # get the circuit
+        if not evc:
+            result = f'circuit_id {circuit_id} not found'
+            log.debug('create_schedule result %s %s', result, 404)
+            raise NotFound(result)
+        # Can not modify circuits deleted and archived
+        if evc.archived:
+            result = f'Circuit {circuit_id} is archived. Update is forbidden.'
+            log.debug('create_schedule result %s %s', result, 403)
+            raise Forbidden(result)
+
+        # new schedule from dict
+        new_schedule = CircuitSchedule.from_dict(schedule_data)
+
+        # If there is no schedule, create the list
+        if not evc.circuit_scheduler:
+            evc.circuit_scheduler = []
+
+        # Add the new schedule
+        evc.circuit_scheduler.append(new_schedule)
+
+        # Add schedule job
+        self.sched.add_circuit_job(evc, new_schedule)
+
+        # save circuit to storehouse
+        evc.sync()
+
+        result = new_schedule.as_dict()
+        status = 201
 
         log.debug('create_schedule result %s %s', result, status)
         return jsonify(result), status
@@ -392,53 +388,51 @@ class Main(KytosNApp):
             }
         """
         log.debug('update_schedule /v2/evc/schedule/%s', schedule_id)
+
+        # Try to find a circuit schedule
+        evc, found_schedule = self._find_evc_by_schedule_id(schedule_id)
+
+        # Can not modify circuits deleted and archived
+        if not found_schedule:
+            result = f'schedule_id {schedule_id} not found'
+            log.debug('update_schedule result %s %s', result, 404)
+            raise NotFound(result)
+        if evc.archived:
+            result = f'Circuit {evc.id} is archived. Update is forbidden.'
+            log.debug('update_schedule result %s %s', result, 403)
+            raise Forbidden(result)
+
         try:
-            # Try to find a circuit schedule
-            evc, found_schedule = self._find_evc_by_schedule_id(schedule_id)
-
-            # Can not modify circuits deleted and archived
-            if not found_schedule:
-                result = {'response': f'schedule_id {schedule_id} not found'}
-                status = 404
-                log.debug('update_schedule result %s %s', result, status)
-                return jsonify(result), status
-            if evc.archived:
-                result = {'response': f'Circuit is archived.'
-                                      f'Update is forbidden.'}
-                status = 403
-                log.debug('update_schedule result %s %s', result, status)
-                return jsonify(result), status
-
             data = request.get_json()
-
-            new_schedule = CircuitSchedule.from_dict(data)
-            new_schedule.id = found_schedule.id
-            # Remove the old schedule
-            evc.circuit_scheduler.remove(found_schedule)
-            # Append the modified schedule
-            evc.circuit_scheduler.append(new_schedule)
-
-            # Cancel all schedule jobs
-            self.sched.cancel_job(found_schedule.id)
-            # Add the new circuit schedule
-            self.sched.add_circuit_job(evc, new_schedule)
-            # Save EVC to the storehouse
-            evc.sync()
-
-            result = new_schedule.as_dict()
-            status = 200
-
         except ValueError as exception:
             log.error(exception)
-            result = {'response': 'Bad Request: {}'.format(exception)}
-            status = 400
-        except TypeError:
-            result = {'response': 'Content-Type must be application/json'}
-            status = 415
+            log.debug('update_schedule result %s %s', exception, 400)
+            raise BadRequest(str(exception))
         except BadRequest:
-            result = {'response':
-                      'Bad Request: The request is not a valid JSON.'}
-            status = 400
+            result = 'The request is not a valid JSON.'
+            log.debug('update_schedule result %s %s', result, 400)
+            raise BadRequest(result)
+        if data is None:
+            result = 'Content-Type must be application/json'
+            log.debug('create_schedule result %s %s', result, 415)
+            raise UnsupportedMediaType(result)
+
+        new_schedule = CircuitSchedule.from_dict(data)
+        new_schedule.id = found_schedule.id
+        # Remove the old schedule
+        evc.circuit_scheduler.remove(found_schedule)
+        # Append the modified schedule
+        evc.circuit_scheduler.append(new_schedule)
+
+        # Cancel all schedule jobs
+        self.sched.cancel_job(found_schedule.id)
+        # Add the new circuit schedule
+        self.sched.add_circuit_job(evc, new_schedule)
+        # Save EVC to the storehouse
+        evc.sync()
+
+        result = new_schedule.as_dict()
+        status = 200
 
         log.debug('update_schedule result %s %s', result, status)
         return jsonify(result), status
@@ -456,16 +450,14 @@ class Main(KytosNApp):
 
         # Can not modify circuits deleted and archived
         if not found_schedule:
-            result = {'response': f'schedule_id {schedule_id} not found'}
-            status = 404
-            log.debug('delete_schedule result %s %s', result, status)
-            return jsonify(result), status
+            result = f'schedule_id {schedule_id} not found'
+            log.debug('delete_schedule result %s %s', result, 404)
+            raise NotFound(result)
 
         if evc.archived:
-            result = {'response': f'Circuit is archived. Update is forbidden.'}
-            status = 403
-            log.debug('delete_schedule result %s %s', result, status)
-            return jsonify(result), status
+            result = f'Circuit {evc.id} is archived. Update is forbidden.'
+            log.debug('delete_schedule result %s %s', result, 403)
+            raise Forbidden(result)
 
         # Remove the old schedule
         evc.circuit_scheduler.remove(found_schedule)

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -298,8 +298,9 @@ class TestMain(TestCase):
         api = self.get_app_test_client(self.napp)
         url = f'{self.server_name_url}/v2/evc/3'
         response = api.get(url)
-        expected_result = {'response': 'circuit_id 3 not found'}
-        self.assertEqual(json.loads(response.data), expected_result)
+        expected_result = 'circuit_id 3 not found'
+        self.assertEqual(json.loads(response.data)['description'],
+                         expected_result)
 
     @patch('napps.kytos.mef_eline.storehouse.StoreHouse.get_data')
     @patch('napps.kytos.mef_eline.scheduler.Scheduler.add')
@@ -405,10 +406,10 @@ class TestMain(TestCase):
 
         response = api.post(url)
         current_data = json.loads(response.data)
-        expected_data = 'Bad request: The request do not have a json.'
+        expected_data = 'The request body mimetype is not application/json.'
 
-        self.assertEqual(400, response.status_code, response.data)
-        self.assertEqual(current_data, expected_data)
+        self.assertEqual(415, response.status_code, response.data)
+        self.assertEqual(current_data['description'], expected_data)
 
     @patch('napps.kytos.mef_eline.scheduler.Scheduler.add')
     @patch('napps.kytos.mef_eline.main.Main._uni_from_dict')
@@ -461,8 +462,8 @@ class TestMain(TestCase):
                             data=json.dumps(payload2),
                             content_type='application/json')
         current_data = json.loads(response.data)
-        expected_data = 'Not Acceptable: This evc already exists.'
-        self.assertEqual(current_data, expected_data)
+        expected_data = 'The EVC already exists.'
+        self.assertEqual(current_data['description'], expected_data)
         self.assertEqual(409, response.status_code)
 
     def test_load_circuits_by_interface(self):
@@ -826,10 +827,10 @@ class TestMain(TestCase):
         # Call URL
         response = api.get(url)
 
-        expected = {'response': 'circuit_id blah not found'}
+        expected = 'circuit_id blah not found'
         # Assert response not found
         self.assertEqual(response.status_code, 404, response.data)
-        self.assertEqual(expected, json.loads(response.data))
+        self.assertEqual(expected, json.loads(response.data)['description'])
 
     def _uni_from_dict_side_effect(self, uni_dict):
         interface_id = uni_dict.get("interface_id")
@@ -1188,7 +1189,7 @@ class TestMain(TestCase):
                              content_type='application/json')
         current_data = json.loads(response.data)
         expected_data = f'circuit_id 1234 not found'
-        self.assertEqual(current_data['response'], expected_data)
+        self.assertEqual(current_data['description'], expected_data)
         self.assertEqual(404, response.status_code)
 
         api.delete(f'{self.server_name_url}/v2/evc/{circuit_id}')
@@ -1250,8 +1251,8 @@ class TestMain(TestCase):
                              data=payload2,
                              content_type='application/json')
         current_data = json.loads(response.data)
-        expected_data = f'Bad Request: The request is not a valid JSON.'
-        self.assertEqual(current_data['response'], expected_data)
+        expected_data = 'The request body is not a well-formed JSON.'
+        self.assertEqual(current_data['description'], expected_data)
         self.assertEqual(400, response.status_code)
 
     def test_handle_link_up(self):


### PR DESCRIPTION
Change the way HTTP errors are handled. Instead of formatting a message for every error
and return the message and error code, use Werkzeug error classes to raise the correct
error code and just modify the description of the error.
Also, fix some errors when dealing with HTTP erros (wrong error code, waiting for an
exception when None is returned).