### PR TITLE
Changed EVC's id size from 128 to 64 bits

### DIFF
--- a/models.py
+++ b/models.py
@@ -194,7 +194,7 @@ class EVCBase(GenericEntity):
         super().__init__()
 
         # required attributes
-        self._id = kwargs.get('id', uuid4().hex)
+        self._id = kwargs.get('id', uuid4().hex[16:])
         self.uni_a = kwargs.get('uni_a')
         self.uni_z = kwargs.get('uni_z')
         self.name = kwargs.get('name')
@@ -711,8 +711,7 @@ class EVCDeploy(EVCBase):
 
     def get_cookie(self):
         """Return the cookie integer from evc id."""
-        value = self.id[len(self.id)//2:]
-        return int(value, 16)
+        return int(self.id, 16)
 
     def _prepare_flow_mod(self, in_interface, out_interface):
         """Prepare a common flow mod."""

--- a/models.py
+++ b/models.py
@@ -194,7 +194,7 @@ class EVCBase(GenericEntity):
         super().__init__()
 
         # required attributes
-        self._id = kwargs.get('id', uuid4().hex[16:])
+        self._id = kwargs.get('id', uuid4().hex[:16])
         self.uni_a = kwargs.get('uni_a')
         self.uni_z = kwargs.get('uni_z')
         self.name = kwargs.get('name')


### PR DESCRIPTION
This way, the size is the same of the cookie field in a flow, making it
easy to convert from one to the other.

### :octocat: Issue

This PR fixes #204.

### :bookmark_tabs: Description of the Change

This changes the `id` size from 128 bits to 64. The `id` is generated using the `hex` representation of a `uuid4` and, as it represents a 128 bits integer, we get the first half of it.
Also, `get_cookie` method, where the cookie was obtained by taking the first half of the `id` and converting to a int base 16, now it just does the conversion.

### :computer: Verification Process

Besides running the unit tests, I tried to create, get and delete an EVC.

### :page_facing_up: Release Notes

 - Changed the size of the EVC id from 128 to 64 bits.