### PR TITLE
Load EVCs after port creation, delay deploy

### DIFF
--- a/main.py
+++ b/main.py
@@ -12,12 +12,10 @@ from kytos.core.events import KytosEvent
 from kytos.core.helpers import listen_to
 from kytos.core.interface import TAG, UNI
 from kytos.core.link import Link
+from napps.kytos.mef_eline import settings
 from napps.kytos.mef_eline.models import EVC, DynamicPathManager, Path
 from napps.kytos.mef_eline.scheduler import CircuitSchedule, Scheduler
 from napps.kytos.mef_eline.storehouse import StoreHouse
-
-
-DEPLOY_EVCS_INTERVAL = 60
 
 
 class Main(KytosNApp):
@@ -50,7 +48,7 @@ class Main(KytosNApp):
         # dictionary of EVCs by interface
         self._circuits_by_interface = {}
 
-        self.execute_as_loop(DEPLOY_EVCS_INTERVAL)
+        self.execute_as_loop(settings.DEPLOY_EVCS_INTERVAL)
 
     def execute(self):
         """Execute once when the napp is running."""
@@ -529,8 +527,6 @@ class Main(KytosNApp):
                 evc.sync()
                 self.circuits.setdefault(circuit_id, evc)
                 self.sched.add(evc)
-        log.info(f'Circuits {self.circuits}')
-
 
     def _evc_dict_with_instances(self, evc_dict):
         """Convert some dict values to instance of EVC classes.

--- a/settings.py
+++ b/settings.py
@@ -8,3 +8,6 @@ MANAGER_URL = 'http://localhost:8181/api/kytos/flow_manager/v2'
 
 # Base URL of the Pathfinder endpoint
 TOPOLOGY_URL = 'http://localhost:8181/api/kytos/topology/v3'
+
+# EVC consistency interval
+DEPLOY_EVCS_INTERVAL = 60


### PR DESCRIPTION
### :octocat: Issue

This PR fixes #207.

### :bookmark_tabs: Change the way stored EVCs are loaded and deployed

EVCs are now loaded after port creation, but not depoyed.
A routine running at predefined interval tries to deploy inactive
enabled EVCs.

### :computer: Verification Process

Tested with an enabled EVC on storehouse.
Unit tests run without issues.

### :page_facing_up: Release Notes

- EVCs are now only loaded on start (not deployed).
- Try to deploy enabled EVCs at a regular interval. 