### PR TITLE
Change real API calls to mock calls on tests

### DIFF
--- a/tests/unit/models/test_evc_deploy.py
+++ b/tests/unit/models/test_evc_deploy.py
@@ -364,6 +364,7 @@ class TestEVC(TestCase):  # pylint: disable=too-many-public-methods
         switch = evc.primary_links[0].endpoint_b.switch
         send_flow_mods_mock.assert_called_once_with(switch, expected_flow_mods)
 
+    @patch('requests.post')
     @patch('napps.kytos.mef_eline.models.log')
     @patch('napps.kytos.mef_eline.models.Path.choose_vlans')
     @patch('napps.kytos.mef_eline.models.EVC._install_nni_flows')
@@ -375,7 +376,7 @@ class TestEVC(TestCase):  # pylint: disable=too-many-public-methods
         # pylint: disable=too-many-locals
         (should_deploy_mock, activate_mock,
          install_uni_flows_mock, install_nni_flows, chose_vlans_mock,
-         log_mock) = args
+         log_mock, _) = args
 
         should_deploy_mock.return_value = True
         uni_a = get_uni_mocked(interface_port=2, tag_value=82,
@@ -418,6 +419,7 @@ class TestEVC(TestCase):  # pylint: disable=too-many-public-methods
         log_mock.info.assert_called_with(f"{evc} was deployed.")
         self.assertTrue(deployed)
 
+    @patch('requests.post')
     @patch('napps.kytos.mef_eline.models.log')
     @patch('napps.kytos.mef_eline.models.EVC.discover_new_paths',
            return_value=[])
@@ -433,7 +435,7 @@ class TestEVC(TestCase):  # pylint: disable=too-many-public-methods
         # pylint: disable=too-many-locals
         (sync_mock, should_deploy_mock, activate_mock, install_uni_flows_mock,
          install_nni_flows, choose_vlans_mock,
-         discover_new_paths, log_mock) = args
+         discover_new_paths, log_mock, _) = args
 
         uni_a = get_uni_mocked(interface_port=2, tag_value=82,
                                switch_id="switch_uni_a",
@@ -470,6 +472,7 @@ class TestEVC(TestCase):  # pylint: disable=too-many-public-methods
         self.assertEqual(sync_mock.call_count, 1)
         self.assertFalse(deployed)
 
+    @patch('requests.post')
     @patch('napps.kytos.mef_eline.models.log')
     @patch('napps.kytos.mef_eline.models.Path.choose_vlans')
     @patch('napps.kytos.mef_eline.models.EVC._install_nni_flows')
@@ -482,7 +485,7 @@ class TestEVC(TestCase):  # pylint: disable=too-many-public-methods
         # pylint: disable=too-many-locals
         (discover_new_paths_mocked, should_deploy_mock, activate_mock,
          install_uni_flows_mock, install_nni_flows, chose_vlans_mock,
-         log_mock) = args
+         log_mock, _) = args
 
         should_deploy_mock.return_value = False
         uni_a = get_uni_mocked(interface_port=2, tag_value=82,

--- a/tests/unit/models/test_link_protection.py
+++ b/tests/unit/models/test_link_protection.py
@@ -88,13 +88,14 @@ class TestLinkProtection(TestCase):  # pylint: disable=too-many-public-methods
         log_mocked.debug.assert_called_with(expected_msg)
         self.assertTrue(expected_deployed)
 
+    @patch('requests.post')
     @patch('napps.kytos.mef_eline.models.EVCDeploy.deploy')
     @patch('napps.kytos.mef_eline.models.EVC._install_nni_flows')
     @patch('napps.kytos.mef_eline.models.EVC._install_uni_flows')
     @patch('napps.kytos.mef_eline.models.Path.status', EntityStatus.UP)
     def test_deploy_to_case_2(self, install_uni_flows_mocked,
                               install_nni_flows_mocked,
-                              deploy_mocked):
+                              deploy_mocked, _):
         """Test deploy with all links up."""
         deploy_mocked.return_value = True
 

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -1095,6 +1095,7 @@ class TestMain(TestCase):
 
         self.assertEqual(response.status_code, 403, response.data)
 
+    @patch('requests.post')
     @patch('napps.kytos.mef_eline.scheduler.Scheduler.add')
     @patch('napps.kytos.mef_eline.storehouse.StoreHouse.save_evc')
     @patch('napps.kytos.mef_eline.models.EVC._validate')


### PR DESCRIPTION
Fixes #211

### :bookmark_tabs: Description of the Change

Some API calls on tests where using real calls, and the tests were
failing when `kytos` was not running. Those calls were replaced by
mocks.

### :computer: Verification Process

Unit tests now running ok.

### :page_facing_up: Release Notes

- Change real API calls to mock calls on tests.
