### PR TITLE
New method to decide if two EVCs share an UNI

### DIFF
--- a/main.py
+++ b/main.py
@@ -456,7 +456,7 @@ class Main(KytosNApp):
 
         """
         for circuit in self.circuits.values():
-            if not circuit.archived and circuit == evc:
+            if not circuit.archived and circuit.share_uni(evc):
                 return True
         return False
 

--- a/models.py
+++ b/models.py
@@ -322,6 +322,13 @@ class EVCBase(GenericEntity):
                 return False
         return True
 
+    def share_uni(self, other):
+        """Check if two EVCs share an UNI."""
+        if other.uni_a in (self.uni_a, self.uni_z) or \
+           other.uni_z in (self.uni_a, self.uni_z):
+            return True
+        return False
+
     def as_dict(self):
         """Return a dictionary representing an EVC object."""
         evc_dict = {"id": self.id, "name": self.name,


### PR DESCRIPTION
Fixes #219 

### :bookmark_tabs: Description of the Change

Two EVCs sharing one UNI were allowed. That caused
the flows from the first EVC to be overwritten by the flows
from the new EVC. With this change, a UNI can appear
in only one EVC.

### :computer: Verification Process

All unit tests are still passing.

### :page_facing_up: Release Notes

- New method to check if two EVCs share a UNI.
- Creation of EVC uses the new method.
