### PR TITLE
Remove user VLAN encapsulation

### DIFF
--- a/models.py
+++ b/models.py
@@ -683,13 +683,14 @@ class EVCDeploy(EVCBase):
         push_flow = self._prepare_push_flow(self.uni_a.interface,
                                             path[0].endpoint_a,
                                             in_vlan_a, out_vlan_a,
-                                            in_vlan_z, queue_id=self.queue_id)
+                                            queue_id=self.queue_id)
         flows_a.append(push_flow)
 
         # Flow for the other direction, popping the service tag
         pop_flow = self._prepare_pop_flow(path[0].endpoint_a,
                                           self.uni_a.interface,
-                                          out_vlan_a, queue_id=self.queue_id)
+                                          in_vlan_a, out_vlan_a, 
+                                          queue_id=self.queue_id)
         flows_a.append(pop_flow)
 
         self._send_flow_mods(self.uni_a.interface.switch, flows_a)
@@ -701,13 +702,14 @@ class EVCDeploy(EVCBase):
         push_flow = self._prepare_push_flow(self.uni_z.interface,
                                             path[-1].endpoint_b,
                                             in_vlan_z, out_vlan_z,
-                                            in_vlan_a, queue_id=self.queue_id)
+                                            queue_id=self.queue_id)
         flows_z.append(push_flow)
 
         # Flow for the other direction, popping the service tag
         pop_flow = self._prepare_pop_flow(path[-1].endpoint_b,
                                           self.uni_z.interface,
-                                          out_vlan_z, queue_id=self.queue_id)
+                                          in_vlan_z, out_vlan_z, 
+                                          queue_id=self.queue_id)
         flows_z.append(pop_flow)
 
         self._send_flow_mods(self.uni_z.interface.switch, flows_z)
@@ -767,14 +769,13 @@ class EVCDeploy(EVCBase):
             out_interface(str): Interface output.
             in_vlan(str): Vlan input.
             out_vlan(str): Vlan output.
-            new_in_vlan(str): Interface input.
 
         Return:
             dict: An python dictionary representing a FlowMod
 
         """
         # assign all arguments
-        in_interface, out_interface, in_vlan, out_vlan, new_in_vlan = args
+        in_interface, out_interface, in_vlan, out_vlan = args
 
         flow_mod = self._prepare_flow_mod(in_interface, out_interface,
                                           queue_id)
@@ -789,28 +790,21 @@ class EVCDeploy(EVCBase):
         if in_vlan:
             # if in_vlan is set, it must be included in the match
             flow_mod['match']['dl_vlan'] = in_vlan
-        if new_in_vlan:
-            # new_in_vlan is set, so an action to set it is necessary
-            new_action = {"action_type": "set_vlan", "vlan_id": new_in_vlan}
-            flow_mod["actions"].insert(0, new_action)
-            if not in_vlan:
-                # new_in_vlan is set, but in_vlan is not, so there was no
-                # vlan set; then it is set now
-                new_action = {"action_type": "push_vlan", "tag_type": "c"}
-                flow_mod["actions"].insert(0, new_action)
-        elif in_vlan:
-            # in_vlan is set, but new_in_vlan is not, so the existing vlan
-            # must be removed
             new_action = {"action_type": "pop_vlan"}
             flow_mod["actions"].insert(0, new_action)
         return flow_mod
 
-    def _prepare_pop_flow(self, in_interface, out_interface, out_vlan,
-                          queue_id=None):
+    def _prepare_pop_flow(self, in_interface, out_interface, in_vlan,
+                          out_vlan, queue_id=None):
         """Prepare pop flow."""
         flow_mod = self._prepare_flow_mod(in_interface, out_interface,
                                           queue_id)
         flow_mod['match']['dl_vlan'] = out_vlan
+        if in_vlan:
+            new_action = {'action_type': 'set_vlan', 'vlan_id': in_vlan}
+            flow_mod['actions'].insert(0, new_action)
+            new_action = {'action_type': 'push_vlan', 'tag_type': 'c'}
+            flow_mod['actions'].insert(0, new_action)
         new_action = {"action_type": "pop_vlan"}
         flow_mod["actions"].insert(0, new_action)
         return flow_mod

--- a/models.py
+++ b/models.py
@@ -689,7 +689,7 @@ class EVCDeploy(EVCBase):
         # Flow for the other direction, popping the service tag
         pop_flow = self._prepare_pop_flow(path[0].endpoint_a,
                                           self.uni_a.interface,
-                                          in_vlan_a, out_vlan_a, 
+                                          in_vlan_a, out_vlan_a,
                                           queue_id=self.queue_id)
         flows_a.append(pop_flow)
 
@@ -708,7 +708,7 @@ class EVCDeploy(EVCBase):
         # Flow for the other direction, popping the service tag
         pop_flow = self._prepare_pop_flow(path[-1].endpoint_b,
                                           self.uni_z.interface,
-                                          in_vlan_z, out_vlan_z, 
+                                          in_vlan_z, out_vlan_z,
                                           queue_id=self.queue_id)
         flows_z.append(pop_flow)
 
@@ -796,6 +796,7 @@ class EVCDeploy(EVCBase):
 
     def _prepare_pop_flow(self, in_interface, out_interface, in_vlan,
                           out_vlan, queue_id=None):
+        # pylint: disable=too-many-arguments
         """Prepare pop flow."""
         flow_mod = self._prepare_flow_mod(in_interface, out_interface,
                                           queue_id)


### PR DESCRIPTION
This pull request fixes #221

### :bookmark_tabs: Description of the Change

This PR removes the encapsulation of user VLAN, avoiding the use
of two set-fields for VLANs in the same flow, which is unsupported
by Noviflow (and maybe by other vendors).

### :computer: Verification Process

Unit tests are passing.

### :page_facing_up: Release Notes

- Removed encapsulation of user VLAN.
