### PR TITLE
Introduce threading locks to avoid race conditions when saving to the storehouse

### DIFF
--- a/models.py
+++ b/models.py
@@ -579,6 +579,8 @@ class EVCDeploy(EVCBase):
                 use_path = None
         else:
             for use_path in self.discover_new_paths():
+                if use_path is None:
+                    continue
                 try:
                     use_path.choose_vlans()
                     break

--- a/storehouse.py
+++ b/storehouse.py
@@ -1,4 +1,6 @@
 """Module to handle the storehouse."""
+import threading
+
 from kytos.core import log
 from kytos.core.events import KytosEvent
 
@@ -20,6 +22,7 @@ class StoreHouse:
         """Create a storehouse instance."""
         self.controller = controller
         self.namespace = 'kytos.mef_eline.circuits'
+        self._lock = threading.Lock()
         if 'box' not in self.__dict__:
             self.box = None
         self.list_stored_boxes()
@@ -86,6 +89,8 @@ class StoreHouse:
 
     def save_evc(self, evc):
         """Save a EVC using the storehouse."""
+        self._lock.acquire()  # Lock to avoid race condition
+        log.info(f'Lock {self._lock} acquired.')
         self.box.data[evc.id] = evc.as_dict()
 
         content = {'namespace': self.namespace,
@@ -98,6 +103,8 @@ class StoreHouse:
 
     def _save_evc_callback(self, _event, data, error):
         """Display the save EVC result in the log."""
+        self._lock.release()
+        log.info(f'Lock {self._lock} acquired.')
         if error:
             log.error(f'Can\'t update the {self.box.box_id}')
 

--- a/storehouse.py
+++ b/storehouse.py
@@ -90,7 +90,7 @@ class StoreHouse:
     def save_evc(self, evc):
         """Save a EVC using the storehouse."""
         self._lock.acquire()  # Lock to avoid race condition
-        log.info(f'Lock {self._lock} acquired.')
+        log.debug(f'Lock {self._lock} acquired.')
         self.box.data[evc.id] = evc.as_dict()
 
         content = {'namespace': self.namespace,
@@ -104,7 +104,7 @@ class StoreHouse:
     def _save_evc_callback(self, _event, data, error):
         """Display the save EVC result in the log."""
         self._lock.release()
-        log.info(f'Lock {self._lock} acquired.')
+        log.debug(f'Lock {self._lock} released.')
         if error:
             log.error(f'Can\'t update the {self.box.box_id}')
 

--- a/tests/unit/models/test_evc_deploy.py
+++ b/tests/unit/models/test_evc_deploy.py
@@ -365,6 +365,7 @@ class TestEVC(TestCase):  # pylint: disable=too-many-public-methods
         send_flow_mods_mock.assert_called_once_with(switch, expected_flow_mods)
 
     @patch('requests.post')
+    @patch('napps.kytos.mef_eline.storehouse.StoreHouse.save_evc')
     @patch('napps.kytos.mef_eline.models.log')
     @patch('napps.kytos.mef_eline.models.Path.choose_vlans')
     @patch('napps.kytos.mef_eline.models.EVC._install_nni_flows')
@@ -376,7 +377,7 @@ class TestEVC(TestCase):  # pylint: disable=too-many-public-methods
         # pylint: disable=too-many-locals
         (should_deploy_mock, activate_mock,
          install_uni_flows_mock, install_nni_flows, chose_vlans_mock,
-         log_mock, _) = args
+         log_mock, _, _) = args
 
         should_deploy_mock.return_value = True
         uni_a = get_uni_mocked(interface_port=2, tag_value=82,
@@ -404,10 +405,6 @@ class TestEVC(TestCase):  # pylint: disable=too-many-public-methods
         path.append(primary_links[1])
 
         evc = EVC(**attributes)
-
-        # storehouse mock
-        evc._storehouse.box = Mock()  # pylint: disable=protected-access
-        evc._storehouse.box.data = {}  # pylint: disable=protected-access
 
         deployed = evc.deploy_to_path(path)
 
@@ -473,6 +470,7 @@ class TestEVC(TestCase):  # pylint: disable=too-many-public-methods
         self.assertFalse(deployed)
 
     @patch('requests.post')
+    @patch('napps.kytos.mef_eline.storehouse.StoreHouse.save_evc')
     @patch('napps.kytos.mef_eline.models.log')
     @patch('napps.kytos.mef_eline.models.Path.choose_vlans')
     @patch('napps.kytos.mef_eline.models.EVC._install_nni_flows')
@@ -485,7 +483,7 @@ class TestEVC(TestCase):  # pylint: disable=too-many-public-methods
         # pylint: disable=too-many-locals
         (discover_new_paths_mocked, should_deploy_mock, activate_mock,
          install_uni_flows_mock, install_nni_flows, chose_vlans_mock,
-         log_mock, _) = args
+         log_mock, _, _) = args
 
         should_deploy_mock.return_value = False
         uni_a = get_uni_mocked(interface_port=2, tag_value=82,
@@ -511,10 +509,6 @@ class TestEVC(TestCase):  # pylint: disable=too-many-public-methods
 
         evc = EVC(**attributes)
         discover_new_paths_mocked.return_value = [dynamic_backup_path]
-
-        # storehouse initialization mock
-        evc._storehouse.box = Mock()  # pylint: disable=protected-access
-        evc._storehouse.box.data = {}  # pylint: disable=protected-access
 
         deployed = evc.deploy_to_path()
 

--- a/tests/unit/models/test_link_protection.py
+++ b/tests/unit/models/test_link_protection.py
@@ -89,13 +89,14 @@ class TestLinkProtection(TestCase):  # pylint: disable=too-many-public-methods
         self.assertTrue(expected_deployed)
 
     @patch('requests.post')
+    @patch('napps.kytos.mef_eline.storehouse.StoreHouse.save_evc')
     @patch('napps.kytos.mef_eline.models.EVCDeploy.deploy')
     @patch('napps.kytos.mef_eline.models.EVC._install_nni_flows')
     @patch('napps.kytos.mef_eline.models.EVC._install_uni_flows')
     @patch('napps.kytos.mef_eline.models.Path.status', EntityStatus.UP)
     def test_deploy_to_case_2(self, install_uni_flows_mocked,
                               install_nni_flows_mocked,
-                              deploy_mocked, _):
+                              deploy_mocked, *_):
         """Test deploy with all links up."""
         deploy_mocked.return_value = True
 
@@ -112,10 +113,6 @@ class TestLinkProtection(TestCase):  # pylint: disable=too-many-public-methods
             "enabled": True
         }
         evc = EVC(**attributes)
-
-        # storehouse mock
-        evc._storehouse.box = Mock()  # pylint: disable=protected-access
-        evc._storehouse.box.data = {}  # pylint: disable=protected-access
 
         deployed = evc.deploy_to('primary_path', evc.primary_path)
         install_uni_flows_mocked.assert_called_with(evc.primary_path)


### PR DESCRIPTION
This pull request fixes #223

### :bookmark_tabs: Description of the Change

This PR introduces a threading lock when saving a EVC.
The lock is acquired before the box is read in `save_evc` and released
in the callback that is called after the backend is written.

### :computer: Verification Process

Unit tests are passing and a lot of manual tests were also run.

### :page_facing_up: Release Notes

- Locks used to avoid race conditions when saving an EVC to the storehouse.