### PR TITLE
Allow a queue id to be used in EVCs

### DIFF
--- a/models.py
+++ b/models.py
@@ -615,9 +615,11 @@ class EVCDeploy(EVCBase):
         vlan_z = self.uni_z.user_tag.value if self.uni_z.user_tag else None
 
         flow_mod_az = self._prepare_flow_mod(self.uni_a.interface,
-                                             self.uni_z.interface)
+                                             self.uni_z.interface, 
+                                             self.queue_id)
         flow_mod_za = self._prepare_flow_mod(self.uni_z.interface,
-                                             self.uni_a.interface)
+                                             self.uni_a.interface,
+                                             self.queue_id)
 
         if vlan_a and vlan_z:
             flow_mod_az['match']['dl_vlan'] = vlan_a
@@ -649,12 +651,14 @@ class EVCDeploy(EVCBase):
             # Flow for one direction
             flows.append(self._prepare_nni_flow(incoming.endpoint_b,
                                                 outcoming.endpoint_a,
-                                                in_vlan, out_vlan))
+                                                in_vlan, out_vlan,
+                                                queue_id=self.queue_id))
 
             # Flow for the other direction
             flows.append(self._prepare_nni_flow(outcoming.endpoint_a,
                                                 incoming.endpoint_b,
-                                                out_vlan, in_vlan))
+                                                out_vlan, in_vlan,
+                                                queue_id=self.queue_id))
             self._send_flow_mods(incoming.endpoint_b.switch, flows)
 
     def _install_uni_flows(self, path=None):
@@ -676,12 +680,14 @@ class EVCDeploy(EVCBase):
         # Flow for one direction, pushing the service tag
         push_flow = self._prepare_push_flow(self.uni_a.interface,
                                             path[0].endpoint_a,
-                                            in_vlan_a, out_vlan_a, in_vlan_z)
+                                            in_vlan_a, out_vlan_a, 
+                                            in_vlan_z, queue_id=self.queue_id)
         flows_a.append(push_flow)
 
         # Flow for the other direction, popping the service tag
         pop_flow = self._prepare_pop_flow(path[0].endpoint_a,
-                                          self.uni_a.interface, out_vlan_a)
+                                          self.uni_a.interface, 
+                                          out_vlan_a, queue_id=self.queue_id)
         flows_a.append(pop_flow)
 
         self._send_flow_mods(self.uni_a.interface.switch, flows_a)
@@ -692,12 +698,14 @@ class EVCDeploy(EVCBase):
         # Flow for one direction, pushing the service tag
         push_flow = self._prepare_push_flow(self.uni_z.interface,
                                             path[-1].endpoint_b,
-                                            in_vlan_z, out_vlan_z, in_vlan_a)
+                                            in_vlan_z, out_vlan_z, 
+                                            in_vlan_a, queue_id=self.queue_id)
         flows_z.append(push_flow)
 
         # Flow for the other direction, popping the service tag
         pop_flow = self._prepare_pop_flow(path[-1].endpoint_b,
-                                          self.uni_z.interface, out_vlan_z)
+                                          self.uni_z.interface, 
+                                          out_vlan_z, queue_id=self.queue_id)
         flows_z.append(pop_flow)
 
         self._send_flow_mods(self.uni_z.interface.switch, flows_z)
@@ -721,21 +729,26 @@ class EVCDeploy(EVCBase):
         """Return the cookie integer from evc id."""
         return int(self.id, 16)
 
-    def _prepare_flow_mod(self, in_interface, out_interface):
+    def _prepare_flow_mod(self, in_interface, out_interface, queue_id=None):
         """Prepare a common flow mod."""
-        default_action = {"action_type": "output",
-                          "port": out_interface.port_number}
+        default_actions = [{"action_type": "output",
+                            "port": out_interface.port_number}]
+        if queue_id:
+            default_actions.append(
+                {"action_type": "set_queue", "queue_id": queue_id}
+            )          
 
         flow_mod = {"match": {"in_port": in_interface.port_number},
                     "cookie": self.get_cookie(),
-                    "actions": [default_action]}
+                    "actions": default_actions}
 
         return flow_mod
 
-    def _prepare_nni_flow(self,
-                          in_interface, out_interface, in_vlan, out_vlan):
+    def _prepare_nni_flow(self, in_interface, out_interface, in_vlan, 
+                          out_vlan, queue_id=None):
         """Create NNI flows."""
-        flow_mod = self._prepare_flow_mod(in_interface, out_interface)
+        flow_mod = self._prepare_flow_mod(in_interface, out_interface, 
+                                          queue_id)
         flow_mod['match']['dl_vlan'] = in_vlan
 
         new_action = {"action_type": "set_vlan",
@@ -744,7 +757,7 @@ class EVCDeploy(EVCBase):
 
         return flow_mod
 
-    def _prepare_push_flow(self, *args):
+    def _prepare_push_flow(self, *args, queue_id=None):
         """Prepare push flow.
 
         Arguments:
@@ -761,7 +774,8 @@ class EVCDeploy(EVCBase):
         # assign all arguments
         in_interface, out_interface, in_vlan, out_vlan, new_in_vlan = args
 
-        flow_mod = self._prepare_flow_mod(in_interface, out_interface)
+        flow_mod = self._prepare_flow_mod(in_interface, out_interface, 
+                                          queue_id)
 
         # the service tag must be always pushed
         new_action = {"action_type": "set_vlan", "vlan_id": out_vlan}
@@ -789,9 +803,11 @@ class EVCDeploy(EVCBase):
             flow_mod["actions"].insert(0, new_action)
         return flow_mod
 
-    def _prepare_pop_flow(self, in_interface, out_interface, out_vlan):
+    def _prepare_pop_flow(self, in_interface, out_interface, out_vlan,
+                          queue_id=None):
         """Prepare pop flow."""
-        flow_mod = self._prepare_flow_mod(in_interface, out_interface)
+        flow_mod = self._prepare_flow_mod(in_interface, out_interface, 
+                                          queue_id)
         flow_mod['match']['dl_vlan'] = out_vlan
         new_action = {"action_type": "pop_vlan"}
         flow_mod["actions"].insert(0, new_action)

--- a/models.py
+++ b/models.py
@@ -615,7 +615,7 @@ class EVCDeploy(EVCBase):
         vlan_z = self.uni_z.user_tag.value if self.uni_z.user_tag else None
 
         flow_mod_az = self._prepare_flow_mod(self.uni_a.interface,
-                                             self.uni_z.interface, 
+                                             self.uni_z.interface,
                                              self.queue_id)
         flow_mod_za = self._prepare_flow_mod(self.uni_z.interface,
                                              self.uni_a.interface,
@@ -680,13 +680,13 @@ class EVCDeploy(EVCBase):
         # Flow for one direction, pushing the service tag
         push_flow = self._prepare_push_flow(self.uni_a.interface,
                                             path[0].endpoint_a,
-                                            in_vlan_a, out_vlan_a, 
+                                            in_vlan_a, out_vlan_a,
                                             in_vlan_z, queue_id=self.queue_id)
         flows_a.append(push_flow)
 
         # Flow for the other direction, popping the service tag
         pop_flow = self._prepare_pop_flow(path[0].endpoint_a,
-                                          self.uni_a.interface, 
+                                          self.uni_a.interface,
                                           out_vlan_a, queue_id=self.queue_id)
         flows_a.append(pop_flow)
 
@@ -698,13 +698,13 @@ class EVCDeploy(EVCBase):
         # Flow for one direction, pushing the service tag
         push_flow = self._prepare_push_flow(self.uni_z.interface,
                                             path[-1].endpoint_b,
-                                            in_vlan_z, out_vlan_z, 
+                                            in_vlan_z, out_vlan_z,
                                             in_vlan_a, queue_id=self.queue_id)
         flows_z.append(push_flow)
 
         # Flow for the other direction, popping the service tag
         pop_flow = self._prepare_pop_flow(path[-1].endpoint_b,
-                                          self.uni_z.interface, 
+                                          self.uni_z.interface,
                                           out_vlan_z, queue_id=self.queue_id)
         flows_z.append(pop_flow)
 
@@ -736,7 +736,7 @@ class EVCDeploy(EVCBase):
         if queue_id:
             default_actions.append(
                 {"action_type": "set_queue", "queue_id": queue_id}
-            )          
+            )
 
         flow_mod = {"match": {"in_port": in_interface.port_number},
                     "cookie": self.get_cookie(),
@@ -744,10 +744,10 @@ class EVCDeploy(EVCBase):
 
         return flow_mod
 
-    def _prepare_nni_flow(self, in_interface, out_interface, in_vlan, 
-                          out_vlan, queue_id=None):
+    def _prepare_nni_flow(self, *args, queue_id=None):
         """Create NNI flows."""
-        flow_mod = self._prepare_flow_mod(in_interface, out_interface, 
+        in_interface, out_interface, in_vlan, out_vlan = args
+        flow_mod = self._prepare_flow_mod(in_interface, out_interface,
                                           queue_id)
         flow_mod['match']['dl_vlan'] = in_vlan
 
@@ -774,7 +774,7 @@ class EVCDeploy(EVCBase):
         # assign all arguments
         in_interface, out_interface, in_vlan, out_vlan, new_in_vlan = args
 
-        flow_mod = self._prepare_flow_mod(in_interface, out_interface, 
+        flow_mod = self._prepare_flow_mod(in_interface, out_interface,
                                           queue_id)
 
         # the service tag must be always pushed
@@ -806,7 +806,7 @@ class EVCDeploy(EVCBase):
     def _prepare_pop_flow(self, in_interface, out_interface, out_vlan,
                           queue_id=None):
         """Prepare pop flow."""
-        flow_mod = self._prepare_flow_mod(in_interface, out_interface, 
+        flow_mod = self._prepare_flow_mod(in_interface, out_interface,
                                           queue_id)
         flow_mod['match']['dl_vlan'] = out_vlan
         new_action = {"action_type": "pop_vlan"}

--- a/models.py
+++ b/models.py
@@ -202,6 +202,7 @@ class EVCBase(GenericEntity):
         # optional attributes
         self.start_date = get_time(kwargs.get('start_date')) or now()
         self.end_date = get_time(kwargs.get('end_date')) or None
+        self.queue_id = kwargs.get('queue_id', None)
 
         self.bandwidth = kwargs.get('bandwidth', 0)
         self.primary_links = Path(kwargs.get('primary_links', []))
@@ -338,6 +339,7 @@ class EVCBase(GenericEntity):
         if isinstance(self.end_date, datetime):
             evc_dict["end_date"] = self.end_date.strftime(time_fmt)
 
+        evc_dict['queue_id'] = self.queue_id
         evc_dict['bandwidth'] = self.bandwidth
         evc_dict['primary_links'] = self.primary_links.as_dict()
         evc_dict['backup_links'] = self.backup_links.as_dict()

--- a/tests/unit/models/test_evc_deploy.py
+++ b/tests/unit/models/test_evc_deploy.py
@@ -397,7 +397,8 @@ class TestEVC(TestCase):  # pylint: disable=too-many-public-methods
             "name": "custom_name",
             "uni_a": uni_a,
             "uni_z": uni_z,
-            "primary_links": primary_links
+            "primary_links": primary_links,
+            "queue_id": 5
         }
         # Setup path to deploy
         path = Path()

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -107,7 +107,8 @@ class TestMain(TestCase):
             "circuit_scheduler": [{
                 "frequency": "* * * * *",
                 "action": "create"
-            }]
+            }],
+            "queue_id": 5
         }
         # pylint: disable=protected-access
         evc_response = self.napp._evc_from_dict(payload)
@@ -116,6 +117,7 @@ class TestMain(TestCase):
         self.assertIsNotNone(evc_response.uni_z)
         self.assertIsNotNone(evc_response.circuit_scheduler)
         self.assertIsNotNone(evc_response.name)
+        self.assertIsNotNone(evc_response.queue_id)
 
     @patch('napps.kytos.mef_eline.main.Main._uni_from_dict')
     @patch('napps.kytos.mef_eline.models.EVCBase._validate')


### PR DESCRIPTION
Fix issue #228.

### :bookmark_tabs: Description of the Change

EVCs now have a queue_id attribute, that can be set by the user on creation/modification.
It is an optional attribute. If it is set, a new action is used for every flow of this
EVC, the `set_queue` action.

### :computer: Verification Process

Unit tests have been modified to test EVC creation with queue_id

### :page_facing_up: Release Notes

- Queue id field created for EVCs.
- Flow from EVCs with queue id set have a set queue action.
