### PR TITLE
Generate log message when an EVC is enabled but cannot be activated

### DIFF
--- a/models.py
+++ b/models.py
@@ -599,6 +599,7 @@ class EVCDeploy(EVCBase):
             self._install_direct_uni_flows()
             use_path = Path()
         else:
+            log.warn(f"{self} was not deployed. No available path was found.")
             return False
         self.activate()
         self.current_path = use_path


### PR DESCRIPTION
Fixes #231

### :bookmark_tabs: Description of the Change

A log message with warning level is generated when an enabled EVC cannot
be activated

### :computer: Verification Process

Unit testes passed.

