### PR TITLE
Add thread lock to EVC

### DIFF
--- a/main.py
+++ b/main.py
@@ -482,7 +482,7 @@ class Main(KytosNApp):
         for evc in self.circuits.values():
             with evc.lock:
                 if evc.is_affected_by_link(event.content['link']):
-                    log.info('handling evc %s' % evc)
+                    log.debug(f'Handling evc {evc.id} on link down')
                     evc.handle_link_down()
 
     def load_circuits_by_interface(self, circuits):

--- a/main.py
+++ b/main.py
@@ -472,16 +472,18 @@ class Main(KytosNApp):
         log.debug("Event handle_link_up %s", event)
         for evc in self.circuits.values():
             if evc.is_enabled() and not evc.archived:
-                evc.handle_link_up(event.content['link'])
+                with evc.lock:
+                    evc.handle_link_up(event.content['link'])
 
     @listen_to('kytos/topology.link_down')
     def handle_link_down(self, event):
         """Change circuit when link is down or under_mantenance."""
         log.debug("Event handle_link_down %s", event)
         for evc in self.circuits.values():
-            if evc.is_affected_by_link(event.content['link']):
-                log.info('handling evc %s' % evc)
-                evc.handle_link_down()
+            with evc.lock:
+                if evc.is_affected_by_link(event.content['link']):
+                    log.info('handling evc %s' % evc)
+                    evc.handle_link_down()
 
     def load_circuits_by_interface(self, circuits):
         """Load circuits in storehouse for in-memory dictionary."""

--- a/models.py
+++ b/models.py
@@ -1,5 +1,6 @@
 """Classes used in the main application."""
 from datetime import datetime
+from threading import Lock
 from uuid import uuid4
 
 import requests
@@ -220,6 +221,8 @@ class EVCBase(GenericEntity):
         self.current_links_cache = set()
         self.primary_links_cache = set()
         self.backup_links_cache = set()
+
+        self.lock = Lock()
 
         self.archived = kwargs.get('archived', False)
 

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -1397,6 +1397,7 @@ class TestMain(TestCase):
         """Test handle_link_up method."""
         evc_mock = create_autospec(EVC)
         evc_mock.is_enabled = MagicMock(side_effect=[True, False, True])
+        evc_mock.lock = MagicMock()
         type(evc_mock).archived = \
             PropertyMock(side_effect=[True, False, False])
         evcs = [evc_mock, evc_mock, evc_mock]
@@ -1410,6 +1411,7 @@ class TestMain(TestCase):
         evc_mock = create_autospec(EVC)
         evc_mock.is_affected_by_link = \
             MagicMock(side_effect=[True, False, True])
+        evc_mock.lock = MagicMock()
         evcs = [evc_mock, evc_mock, evc_mock]
         event = KytosEvent(name='test', content={'link': 'abc'})
         self.napp.circuits = dict(zip(['1', '2', '3'], evcs))


### PR DESCRIPTION
Fix #243

### :bookmark_tabs: Description of the Change

A lock threading lock has been added to the EVC class. With this lock it is possible
to avoid race conditions when handling link status changes.
Without the lock, it was possible that `handle_link_down` may be called in an EVC
before a previous call ends, using an old state and leading to unpredictable results.

### :computer: Verification Process

The manual test described in the issue was run, and the unit tests passed.

### :page_facing_up: Release Notes

- Threading lock added to the EVC and used before handling link up/down.
