### PR TITLE
Fix mef_eline kytos UI to list and create EVCs

### DIFF
--- a/ui/k-info-panel/list_connections.kytos
+++ b/ui/k-info-panel/list_connections.kytos
@@ -1,5 +1,5 @@
 <template>
-    <k-table v-if="this.emptyTable" title="List of EVCs"
+    <k-table v-if="this.rows.length" title="List of EVCs"
         :headers="this.headers"
         :rows="this.rows">
     </k-table>

--- a/ui/k-toolbar/main.kytos
+++ b/ui/k-toolbar/main.kytos
@@ -94,6 +94,8 @@ module.exports = {
     request_circuit () {
         var request = {
             "name" : this.circuit_name,
+            "dynamic_backup_path": true,
+            "enabled": true,
             "uni_a": {"interface_id": this.endpoint_a},
             "uni_z": {"interface_id": this.endpoint_z}
         }
@@ -108,7 +110,7 @@ module.exports = {
         }
         
         let circuit_request = $.ajax({
-                                url: this.url,
+                                url: this.$kytos_server_api + "kytos/mef_eline/v2/evc/",
                                 type:"POST",
                                 data: JSON.stringify(request),
                                 dataType: "json",


### PR DESCRIPTION
Fix #206 

### :bookmark_tabs: Description of the Change

Fix an error on the mef_eline UI that prevents from creating and listing EVCs:
- the URL path was wrong (URL.path=/, instead of /api/kytos/mef_eline/v2/evc, resulting in 405 method not supported)
- the vuejs table condition was wrongly defined, resulting in a empty table even when EVCs were created
- adding two new parameters to the EVC creation: dynamic_backup_path and enabled, which will allow mef_eline to actually enable an EVC
- 
### :computer: Verification Process

I've run manual tests to validate the UI behavior after the changes.

### :page_facing_up: Release Notes

- Fix an issue where the mef_eline UI didn't allow to create EVCs (return HTTP code 405 - method not supported) or create an EVC which never get active (dynamic_backup_path=False and enabled=False)
- Fix an issue where the List Installed EVCs didn't work properly, showing an empty table even if many EVCs exist. 
